### PR TITLE
feat: Implement Logs endpoints

### DIFF
--- a/AppiumFuncTests/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumFuncTests.swift
@@ -22,7 +22,7 @@ class AppiumFuncTests: XCTestCase {
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
             DesiredCapabilitiesEnum.app: "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
-            DesiredCapabilitiesEnum.platformVersion: "13.4",
+            DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"
         ]
@@ -169,6 +169,16 @@ class AppiumFuncTests: XCTestCase {
         do {
             let settings = try driver.getSettings()
             XCTAssertNotNil(settings)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testCanGetAvailableLogTypes() {
+        do {
+            let availableLogTypes = try driver.getAvailableLogTypes()
+            XCTAssertFalse(availableLogTypes.isEmpty)
+            print(availableLogTypes)
         } catch {
             XCTFail("\(error)")
         }

--- a/AppiumFuncTests/IOSDriverTests.swift
+++ b/AppiumFuncTests/IOSDriverTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import AppiumSwiftClient
 
-class SetSettingTest: XCTestCase {
+class IOSDriverTests: XCTestCase {
     var driver: IOSDriver!
 
     override func setUp() {
@@ -21,7 +21,7 @@ class SetSettingTest: XCTestCase {
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
             DesiredCapabilitiesEnum.app: "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
-            DesiredCapabilitiesEnum.platformVersion: "13.4",
+            DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"
         ]
@@ -41,6 +41,15 @@ class SetSettingTest: XCTestCase {
             let mjpegServerFramerateAfter = settingsAfter["mjpegServerFramerate"] as! Int // swiftlint:disable:this force_cast
             XCTAssertNotEqual(mjpegServerFramerateBefore, mjpegServerFramerateAfter)
         } catch let error {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testCanGetSyslog() {
+        do {
+            let syslog = try driver.getSyslog()
+            XCTAssertFalse(syslog.isEmpty)
+        } catch {
             XCTFail("\(error)")
         }
     }

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358921DA46C900CBE9E3 /* CurrentContextTests.swift */; };
 		7213358C21DA47F700CBE9E3 /* SetContectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358B21DA47F700CBE9E3 /* SetContectTests.swift */; };
 		7213358E21DA488200CBE9E3 /* SetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358D21DA488200CBE9E3 /* SetContext.swift */; };
+		723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */; };
+		723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */; };
 		7246FB3921DB3F10004CDA8F /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */; };
 		7246FB3C21DB3FA2004CDA8F /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */; };
 		7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */; };
@@ -119,6 +121,8 @@
 		7213358921DA46C900CBE9E3 /* CurrentContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentContextTests.swift; sourceTree = "<group>"; };
 		7213358B21DA47F700CBE9E3 /* SetContectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContectTests.swift; sourceTree = "<group>"; };
 		7213358D21DA488200CBE9E3 /* SetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContext.swift; sourceTree = "<group>"; };
+		723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypes.swift; sourceTree = "<group>"; };
+		723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypesTests.swift; sourceTree = "<group>"; };
 		7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CElementScreenshot.swift; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 				72CA79632464085500988CDE /* TimeoutTests.swift */,
 				72E0FF4A24741D9500F6EE8A /* GetSettingsTest.swift */,
 				72C0CDAD2475E13000657933 /* SetSettingsTests.swift */,
+				723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */,
 			);
 			path = W3C;
 			sourceTree = "<group>";
@@ -428,6 +433,7 @@
 				728DD59B2461A665004E6800 /* GoBack.swift */,
 				728AAE0C2473F83900B2F8D8 /* GetSettings.swift */,
 				724BF8DC247530BE0008FA15 /* SetSettings.swift */,
+				723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */,
 			);
 			path = W3C;
 			sourceTree = "<group>";
@@ -779,6 +785,7 @@
 				728DD59C2461A665004E6800 /* GoBack.swift in Sources */,
 				726196BD2199D67900730A67 /* Element.swift in Sources */,
 				726196C6219D35F700730A67 /* WebDriverError.swift in Sources */,
+				723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */,
 				726196B52199BF9800730A67 /* CommandProtocol.swift in Sources */,
 				726196BF2199D75700730A67 /* Click.swift in Sources */,
 				726196B92199C28300730A67 /* FindElement.swift in Sources */,
@@ -825,6 +832,7 @@
 				7213358421DA284B00CBE9E3 /* AvailableContextsTests.swift in Sources */,
 				726196962194948900730A67 /* AppiumSwiftClientUnitTests.swift in Sources */,
 				7252E19421A260EC000B5855 /* AppiumSwiftClientTestBase.swift in Sources */,
+				723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */,
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
 				72CA79642464085500988CDE /* TimeoutTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7213358E21DA488200CBE9E3 /* SetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358D21DA488200CBE9E3 /* SetContext.swift */; };
 		723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */; };
 		723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */; };
+		723673C5247E7654006009C8 /* GetLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C4247E7654006009C8 /* GetLog.swift */; };
 		7246FB3921DB3F10004CDA8F /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */; };
 		7246FB3C21DB3FA2004CDA8F /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */; };
 		7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */; };
@@ -59,7 +60,7 @@
 		728DD59C2461A665004E6800 /* GoBack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59B2461A665004E6800 /* GoBack.swift */; };
 		728DD5A02461DF6E004E6800 /* GoBackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59F2461DF6E004E6800 /* GoBackTest.swift */; };
 		72C0CDAA2475D00A00657933 /* AnyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDA92475D00900657933 /* AnyValue.swift */; };
-		72C0CDAC2475DE1E00657933 /* SetSettingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAB2475DE1E00657933 /* SetSettingTest.swift */; };
+		72C0CDAC2475DE1E00657933 /* IOSDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAB2475DE1E00657933 /* IOSDriverTests.swift */; };
 		72C0CDAE2475E13000657933 /* SetSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAD2475E13000657933 /* SetSettingsTests.swift */; };
 		72C0CDB02475E2FF00657933 /* IOSDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAF2475E2FF00657933 /* IOSDriver.swift */; };
 		72C0CDB22475E35A00657933 /* AndroidDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDB12475E35A00657933 /* AndroidDriver.swift */; };
@@ -75,6 +76,7 @@
 		72CA79642464085500988CDE /* TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CA79632464085500988CDE /* TimeoutTests.swift */; };
 		72E0FF4B24741D9500F6EE8A /* GetSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E0FF4A24741D9500F6EE8A /* GetSettingsTest.swift */; };
 		72E6E5A7245F580F004E8A0C /* EndSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E6E5A6245F580F004E8A0C /* EndSession.swift */; };
+		72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F2ADB42481158D0017B51B /* GetLogTests.swift */; };
 		B56734569980A912ACF56DD3 /* Pods_AppiumFuncTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6E6ECFC48DFA5AE5D6A70AC /* Pods_AppiumFuncTests.framework */; };
 		E28580FF8C70AAAB238380C8 /* Pods_AppiumSwiftClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B97571B30B80D0F7CDF96796 /* Pods_AppiumSwiftClient.framework */; };
 		EC5272DF704D29C639E20678 /* Pods_AppiumSwiftClientUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C4D6C775222B615F1F73876 /* Pods_AppiumSwiftClientUnitTests.framework */; };
@@ -123,6 +125,7 @@
 		7213358D21DA488200CBE9E3 /* SetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContext.swift; sourceTree = "<group>"; };
 		723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypes.swift; sourceTree = "<group>"; };
 		723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypesTests.swift; sourceTree = "<group>"; };
+		723673C4247E7654006009C8 /* GetLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLog.swift; sourceTree = "<group>"; };
 		7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CElementScreenshot.swift; sourceTree = "<group>"; };
@@ -168,7 +171,7 @@
 		728DD59B2461A665004E6800 /* GoBack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBack.swift; sourceTree = "<group>"; };
 		728DD59F2461DF6E004E6800 /* GoBackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBackTest.swift; sourceTree = "<group>"; };
 		72C0CDA92475D00900657933 /* AnyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyValue.swift; sourceTree = "<group>"; };
-		72C0CDAB2475DE1E00657933 /* SetSettingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetSettingTest.swift; sourceTree = "<group>"; };
+		72C0CDAB2475DE1E00657933 /* IOSDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSDriverTests.swift; sourceTree = "<group>"; };
 		72C0CDAD2475E13000657933 /* SetSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetSettingsTests.swift; sourceTree = "<group>"; };
 		72C0CDAF2475E2FF00657933 /* IOSDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSDriver.swift; sourceTree = "<group>"; };
 		72C0CDB12475E35A00657933 /* AndroidDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndroidDriver.swift; sourceTree = "<group>"; };
@@ -184,6 +187,7 @@
 		72CA79632464085500988CDE /* TimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeoutTests.swift; sourceTree = "<group>"; };
 		72E0FF4A24741D9500F6EE8A /* GetSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSettingsTest.swift; sourceTree = "<group>"; };
 		72E6E5A6245F580F004E8A0C /* EndSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndSession.swift; sourceTree = "<group>"; };
+		72F2ADB42481158D0017B51B /* GetLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLogTests.swift; sourceTree = "<group>"; };
 		7786E63B28F1CA6CB9369CAD /* Pods-AppiumFuncTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppiumFuncTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AppiumFuncTests/Pods-AppiumFuncTests.debug.xcconfig"; sourceTree = "<group>"; };
 		829351B1E5E17CE108DB2E0E /* Pods-AppiumSwiftClientUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppiumSwiftClientUnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AppiumSwiftClientUnitTests/Pods-AppiumSwiftClientUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		89DEB940E024EED2A2C4CC51 /* Pods-AppiumSwiftClientUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppiumSwiftClientUnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AppiumSwiftClientUnitTests/Pods-AppiumSwiftClientUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -299,6 +303,7 @@
 				72E0FF4A24741D9500F6EE8A /* GetSettingsTest.swift */,
 				72C0CDAD2475E13000657933 /* SetSettingsTests.swift */,
 				723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */,
+				72F2ADB42481158D0017B51B /* GetLogTests.swift */,
 			);
 			path = W3C;
 			sourceTree = "<group>";
@@ -312,7 +317,7 @@
 				72C6773D24699CA500176D85 /* LandscapeOrientationTest.swift */,
 				72C6773F2469C9C100176D85 /* FunctionalBaseTest.swift */,
 				72C677412469CE8D00176D85 /* PortraitOrientationTest.swift */,
-				72C0CDAB2475DE1E00657933 /* SetSettingTest.swift */,
+				72C0CDAB2475DE1E00657933 /* IOSDriverTests.swift */,
 			);
 			path = AppiumFuncTests;
 			sourceTree = "<group>";
@@ -434,6 +439,7 @@
 				728AAE0C2473F83900B2F8D8 /* GetSettings.swift */,
 				724BF8DC247530BE0008FA15 /* SetSettings.swift */,
 				723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */,
+				723673C4247E7654006009C8 /* GetLog.swift */,
 			);
 			path = W3C;
 			sourceTree = "<group>";
@@ -768,7 +774,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72C6773E24699CA500176D85 /* LandscapeOrientationTest.swift in Sources */,
-				72C0CDAC2475DE1E00657933 /* SetSettingTest.swift in Sources */,
+				72C0CDAC2475DE1E00657933 /* IOSDriverTests.swift in Sources */,
 				72C677422469CE8D00176D85 /* PortraitOrientationTest.swift in Sources */,
 				72C677402469C9C100176D85 /* FunctionalBaseTest.swift in Sources */,
 				7252E1A021A29C4D000B5855 /* AppiumFuncTests.swift in Sources */,
@@ -796,6 +802,7 @@
 				7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */,
 				72686A9B21A1B3670042D385 /* GetCapabilities.swift in Sources */,
 				72C6773324696B3400176D85 /* GetScreenOrientation.swift in Sources */,
+				723673C5247E7654006009C8 /* GetLog.swift in Sources */,
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
 				726196B02199790A00730A67 /* Method.swift in Sources */,
 				720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */,
@@ -835,6 +842,7 @@
 				723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */,
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
+				72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */,
 				72CA79642464085500988CDE /* TimeoutTests.swift in Sources */,
 				7252E1B521A4407A000B5855 /* ClickTests.swift in Sources */,
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,

--- a/AppiumSwiftClient/command/W3C/GetAvailableLogTypes.swift
+++ b/AppiumSwiftClient/command/W3C/GetAvailableLogTypes.swift
@@ -1,0 +1,44 @@
+//
+//  GetLogTypes.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 27.05.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+struct W3CGetAvailableLogTypes: CommandProtocol {
+    func sendRequest(with sessionId: Session.Id) throws -> [String] {
+        let json = generateBodyData()
+        let (statusCode, returnValue) = HttpClient().sendSyncRequest(method: W3CCommands.getAvailableLogTypes.0, commandPath: commandUrl(with: sessionId), json: json)
+        if statusCode == 200 {
+            return returnValue["value"] as! [String] // swiftlint:disable:this force_cast
+        } else {
+            print("Command Get Available Log Types Failed for \(sessionId) with Status Code: \(statusCode)")
+            print(returnValue)
+            let webDriverError = WebDriverError(errorResult: returnValue["value"] as! [String: String]) // swiftlint:disable:this force_cast
+            try webDriverError.raise()
+            return [""]
+        }
+    }
+    func commandUrl(with sessionId: Session.Id, and _: Element.Id = "") -> W3CCommands.CommandPath {
+        return W3CCommands().url(for: W3CCommands.getAvailableLogTypes, with: sessionId)
+    }
+
+    func generateBodyData() -> Data {
+        let getAvailableLogTypes = CommandParam()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        do {
+            return try encoder.encode(getAvailableLogTypes)
+        } catch {
+            return "{}".data(using: .utf8)!
+        }
+    }
+
+    fileprivate struct CommandParam: CommandParamProtocol {
+    }
+}

--- a/AppiumSwiftClient/command/W3C/GetLog.swift
+++ b/AppiumSwiftClient/command/W3C/GetLog.swift
@@ -1,0 +1,86 @@
+//
+//  GetLogs.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 27.05.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+struct W3CGetLog: CommandProtocol {
+    func sendRequest(with sessionId: Session.Id, and logType: String) throws -> [LogEntry] {
+        let json = generateBodyData(type: logType)
+        /*
+         POC: User overload sendSyncRequest fuction that returns Data from response
+         */
+        let (statusCode, returnData) = HttpClient().sendSyncRequestReturningData(method: W3CCommands.getLog.0, commandPath: commandUrl(with: sessionId), json: json)
+
+        /*
+         POC: We should first check for status code and throw the appropriate WebDriverError in case
+         the request fails, skipping decoding process to LogEntry type altogether.
+         */
+        guard statusCode == 200 else {
+            print("Command Get Log \(logType) Failed for \(sessionId) with Status Code: \(statusCode)")
+            let webDriverError = WebDriverError(errorResult: returnData)
+            throw try webDriverError.raise()
+        }
+
+        /*
+         POC: If request was succesful then we proceed with decoding Data into appropriate type. In this case, the response is a an Array of LogEntry.
+         */
+        let result = try JSONDecoder().decode(ValueArrayOf<LogEntry>.self, from: returnData)
+        return result.value
+    }
+
+    func commandUrl(with sessionId: Session.Id, and _: Element.Id = "") -> W3CCommands.CommandPath {
+        return W3CCommands().url(for: W3CCommands.getLog, with: sessionId)
+    }
+
+    func generateBodyData(type logType: String) -> Data {
+        let getLog = CommandParam(type: logType)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        do {
+            return try encoder.encode(getLog.toDictionary())
+        } catch {
+            return "Invalid JSON".data(using: .utf8)!
+        }
+    }
+
+    fileprivate struct CommandParam: CommandParamProtocol {
+        let type: String
+
+        func toDictionary() -> [String: String] {
+            return ["type": type.self]
+        }
+    }
+}
+
+/*
+ POC: A struct that represents the LogEntry object from response
+ */
+public struct LogEntry: Codable {
+    let message: String
+    let level: String
+    let timestamp: Int
+}
+
+/*
+POC: Generic struct that accepts decodable conformant types that represents a driver response. It is meant
+to be a reusable struct and should be placed in its own file and used whenever fit (Mostly POST request
+responses as it does not decode sessionId value?)
+*/
+struct ValueArrayOf<T: Codable>: Codable {
+    let value: [T]
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+    }
+
+    init(from decoder: Decoder) {
+        let container = try! decoder.container(keyedBy: CodingKeys.self) // swiftlint:disable:this force_try
+        value = try! container.decode([T].self, forKey: .value) // swiftlint:disable:this force_try
+    }
+}

--- a/AppiumSwiftClient/common/AndroidDriver.swift
+++ b/AppiumSwiftClient/common/AndroidDriver.swift
@@ -18,6 +18,8 @@ protocol AndroidDriverProtocol: DriverProtocol {
     func setKeyInjectionDelay(timeInMilliseconds: Int) throws -> String
     func setShutdownOnPowerDisconnect(to value: Bool) throws -> String
     func setTrackScrollEvents(to value: Bool) throws -> String
+    func getLogcat() throws -> [LogEntry]
+    func getBugReportLog() throws -> [LogEntry]
 }
 
 public class AndroidDriver: AppiumDriver, AndroidDriverProtocol {
@@ -64,5 +66,13 @@ public class AndroidDriver: AppiumDriver, AndroidDriverProtocol {
 
     @discardableResult public func setTrackScrollEvents(to value: Bool) throws -> String {
         return try setSettings(this: SettingsEnum.trackScrollEvents.rawValue, and: AnyValue(value))
+    }
+
+    public func getLogcat() throws -> [LogEntry] {
+        return try super.getLog(logType: "logcat")
+    }
+
+    public func getBugReportLog() throws -> [LogEntry] {
+        return try super.getLog(logType: "bugreport")
     }
 }

--- a/AppiumSwiftClient/common/IOSDriver.swift
+++ b/AppiumSwiftClient/common/IOSDriver.swift
@@ -24,6 +24,11 @@ protocol IOSDriverProtocol: DriverProtocol {
     func setAcceptAlertButtonSelector(to value: String) throws -> String
     func setDismissAlertButtonSelector(to value: String) throws -> String
     func setScreenshotOrientation(to value: String) throws -> String
+    func getSyslog() throws -> [LogEntry]
+    func getCrashlog() throws -> [LogEntry]
+    func getPerformanceLog() throws -> [LogEntry]
+    func getSafariConsoleLog() throws -> [LogEntry]
+    func getSafariNetworkLog() throws -> [LogEntry]
 }
 
 public class IOSDriver: AppiumDriver, IOSDriverProtocol {
@@ -94,5 +99,25 @@ public class IOSDriver: AppiumDriver, IOSDriverProtocol {
 
     @discardableResult public func setScreenshotOrientation(to value: String) throws -> String {
         return try setSettings(this: SettingsEnum.screenshotOrientation.rawValue, and: AnyValue(value))
+    }
+
+    public func getSyslog() throws -> [LogEntry] {
+        return try super.getLog(logType: "syslog")
+    }
+
+    public func getCrashlog() throws -> [LogEntry] {
+        return try super.getLog(logType: "crashlog")
+    }
+
+    public func getPerformanceLog() throws -> [LogEntry] {
+        return try super.getLog(logType: "performance")
+    }
+
+    public func getSafariConsoleLog() throws -> [LogEntry] {
+        return try super.getLog(logType: "safariConsole")
+    }
+
+    public func getSafariNetworkLog() throws -> [LogEntry] {
+        return try super.getLog(logType: "safariNetwork")
     }
 }

--- a/AppiumSwiftClient/common/driver.swift
+++ b/AppiumSwiftClient/common/driver.swift
@@ -170,6 +170,10 @@ public class AppiumDriver: DriverProtocol {
     @discardableResult public func setElementResponseAttributes(to value: String) throws -> String {
         return try setSettings(this: SettingsEnum.elementResponseAttributes.rawValue, and: AnyValue(value))
     }
+    
+    public func getAvailableLogTypes() throws -> [String] {
+        return try W3CGetAvailableLogTypes().sendRequest(with: currentSession.id)
+    }
 
     @discardableResult public func quit() -> String {
         return W3CEndSession().sendRequest(with: currentSession.id)

--- a/AppiumSwiftClient/common/driver.swift
+++ b/AppiumSwiftClient/common/driver.swift
@@ -31,6 +31,9 @@ protocol DriverProtocol {
     func setSettings(this setting: SettingsEnum.RawValue, and value: AnyValue) throws -> String
     func setShouldUseCompactResponsesSetting(to value: Bool) throws -> String
     func setElementResponseAttributes(to value: String) throws -> String
+    func getAvailableLogTypes() throws -> [String]
+    func getLog(logType: String) throws -> [LogEntry]
+    func getServerLog() throws -> [LogEntry]
     func quit() -> String
 }
 
@@ -170,9 +173,17 @@ public class AppiumDriver: DriverProtocol {
     @discardableResult public func setElementResponseAttributes(to value: String) throws -> String {
         return try setSettings(this: SettingsEnum.elementResponseAttributes.rawValue, and: AnyValue(value))
     }
-    
+
     public func getAvailableLogTypes() throws -> [String] {
         return try W3CGetAvailableLogTypes().sendRequest(with: currentSession.id)
+    }
+
+    public func getLog(logType: String) throws -> [LogEntry] {
+        return try W3CGetLog().sendRequest(with: currentSession.id, and: logType)
+    }
+
+    public func getServerLog() throws -> [LogEntry] {
+        return try getLog(logType: "server")
     }
 
     @discardableResult public func quit() -> String {

--- a/AppiumSwiftClientUnitTests/command/W3C/GetAvailableLogTypesTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/GetAvailableLogTypesTests.swift
@@ -1,0 +1,52 @@
+//
+//  W3CGetAvailableLogTypesTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 27.05.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetAvailableLogTypesTests: AppiumSwiftClientTestBase {
+    
+    func testCanGetAvailableLogTypesTest() {
+        let body = [
+            "value": [
+                "syslog",
+                "crashlog",
+                "performance",
+                "server",
+                "safariConsole",
+                "safariNetwork"
+            ]
+        ]
+        
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/log/types") {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        
+        stub(matcher, json(body, status: 200))
+        let driver = try! AppiumDriver(AppiumCapabilities(super.opts))
+        do {
+            let logTypes = try driver.getAvailableLogTypes()
+            XCTAssertFalse(logTypes.isEmpty)
+            XCTAssertTrue(logTypes.contains("syslog"))
+            XCTAssertTrue(logTypes.contains("crashlog"))
+            XCTAssertTrue(logTypes.contains("performance"))
+            XCTAssertTrue(logTypes.contains("server"))
+            XCTAssertTrue(logTypes.contains("safariConsole"))
+            XCTAssertTrue(logTypes.contains("safariNetwork"))
+        } catch {
+            XCTFail()
+        }
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/GetLogTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/GetLogTests.swift
@@ -1,0 +1,87 @@
+//
+//  GeLogTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 29.05.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetLogTests: AppiumSwiftClientTestBase {
+    
+    func testCanGetSyslogTest() {
+        /*
+         Mock response from appium server, encode it to Data
+         */
+        let response = """
+        {
+          "value": [
+            {
+              "timestamp": 1590746803861,
+              "level": "ALL",
+              "message": "2020-05-29 12:06:43.858 Df runningboardd[2308:ee9f] [com.apple.runningboard:power] Attempting to rename power assertion 34565 for target application<com.facebook.WebDriverAgentRunner.xctrunner> to application<com.facebook.WebDriverAgentRunner.xctrunner>2308-2440-37:Developer testing(BackgroundUI)"
+            },
+            {
+              "timestamp": 1590746803958,
+              "level": "ALL",
+              "message": "2020-05-29 12:06:43.957 Df DTServiceHub[2457:e8ca] [com.apple.dt.instruments:heartbeat] Heartbeat"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/log") {
+                XCTAssertEqual(HttpMethod.post.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+
+        /*
+         Use jsonData instead of json
+         */
+        stub(matcher, jsonData(response, status: 200))
+        let driver = try! IOSDriver(AppiumCapabilities(super.opts))
+        do {
+            let syslog = try driver.getSyslog()
+            XCTAssertTrue(syslog.count == 2)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testGetSyslogFailsWith404() {
+        let response = """
+            {
+              "value": {
+                "error": "invalid session id",
+                "message": "A session is either terminated or not started",
+                "stacktrace": "NoSuchDriverError: A session is either terminated or not started\\n    at asyncHandler (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:255:15)"
+              }
+            }
+            """.data(using: .utf8)!
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/log") {
+                XCTAssertEqual(HttpMethod.post.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+
+        stub(matcher, jsonData(response, status: 404))
+        let driver = try! IOSDriver(AppiumCapabilities(super.opts))
+        XCTAssertThrowsError(try driver.getSyslog()) {
+            error in guard case WebDriverErrorEnum.invalidSessionIdError(error: let error) = error else {
+                return XCTFail()
+            }
+            XCTAssertEqual(error.error, "invalid session id")
+        }
+    }
+}


### PR DESCRIPTION
- Implement [Get Log Types](https://trello.com/c/16fNK2DS/11-implement-get-log-types-endpoint)  and [Get Logs](https://trello.com/c/2wJ3NaZ8/12-implement-get-logs-endpoint) endpoints
- Add POC for client refactor:
> Add `sendSyncRequestReturningData` function, a slightly tweaked version of `sendSyncRequest` function where it returns the response Data rather than a Dictionary. With this change, it is up to the Endpoint implementation to handle the data accordingly resulting in a cleaner implementation with less force casts and taking advantage of types

> Overload WebDriverError constructor to accept Data type in case a request fails

> Add generic types for `ValueOf<T>` and `ValueArrayOf<T>` where `T` is the type we want to decode out of the request responses

At this point this POC is only implemented for `W3CGetLog` struct and a new pull request refactoring remaining W3C endpoint implementations would ensue plus a some improvements around the PC itself should be performed, should these proposed changes be accepted.