### PR TITLE
feat: Implements LogEvents and GetEvents endpoints

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,3 +7,4 @@ excluded:
 disabled_rules: # rule identifiers to exclude from running
   - force_try
   - line_length
+  - force_cast

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -184,4 +184,13 @@ class AppiumFuncTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+
+    func testCanLogCustomEventsAndRetreiveEvents() {
+        let events = try? driver.getEvents()
+        guard let countBefore = events?.events.count else { return }
+        driver.logEvent(with: "Appium", and: "funEvent")
+        let eventsAfter = try? driver.getEvents()
+        guard let countAfter = eventsAfter?.events.count else { return }
+        XCTAssertTrue(countAfter > countBefore)
+    }
 }

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -59,6 +59,10 @@
 		728AAE0D2473F83900B2F8D8 /* GetSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728AAE0C2473F83900B2F8D8 /* GetSettings.swift */; };
 		728DD59C2461A665004E6800 /* GoBack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59B2461A665004E6800 /* GoBack.swift */; };
 		728DD5A02461DF6E004E6800 /* GoBackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59F2461DF6E004E6800 /* GoBackTest.swift */; };
+		729BD0ED249D0567008025F0 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BD0EC249D0567008025F0 /* LogEvent.swift */; };
+		729BD0EF249D113B008025F0 /* LogEventTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BD0EE249D113B008025F0 /* LogEventTest.swift */; };
+		729BD0F3249D1F93008025F0 /* GetEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BD0F2249D1F93008025F0 /* GetEvents.swift */; };
+		72AE3D19249F9E9F00D242E3 /* GetEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AE3D18249F9E9F00D242E3 /* GetEventsTests.swift */; };
 		72C0CDAA2475D00A00657933 /* AnyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDA92475D00900657933 /* AnyValue.swift */; };
 		72C0CDAC2475DE1E00657933 /* IOSDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAB2475DE1E00657933 /* IOSDriverTests.swift */; };
 		72C0CDAE2475E13000657933 /* SetSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C0CDAD2475E13000657933 /* SetSettingsTests.swift */; };
@@ -170,6 +174,10 @@
 		728AAE0C2473F83900B2F8D8 /* GetSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSettings.swift; sourceTree = "<group>"; };
 		728DD59B2461A665004E6800 /* GoBack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBack.swift; sourceTree = "<group>"; };
 		728DD59F2461DF6E004E6800 /* GoBackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBackTest.swift; sourceTree = "<group>"; };
+		729BD0EC249D0567008025F0 /* LogEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
+		729BD0EE249D113B008025F0 /* LogEventTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventTest.swift; sourceTree = "<group>"; };
+		729BD0F2249D1F93008025F0 /* GetEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetEvents.swift; sourceTree = "<group>"; };
+		72AE3D18249F9E9F00D242E3 /* GetEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetEventsTests.swift; sourceTree = "<group>"; };
 		72C0CDA92475D00900657933 /* AnyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyValue.swift; sourceTree = "<group>"; };
 		72C0CDAB2475DE1E00657933 /* IOSDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSDriverTests.swift; sourceTree = "<group>"; };
 		72C0CDAD2475E13000657933 /* SetSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetSettingsTests.swift; sourceTree = "<group>"; };
@@ -288,6 +296,7 @@
 		7252E19021A25FA1000B5855 /* W3C */ = {
 			isa = PBXGroup;
 			children = (
+				72AE3D1A24A11BB300D242E3 /* events */,
 				72C677442469D17D00176D85 /* orientation */,
 				7246FB3721DB3EF1004CDA8F /* screenshot */,
 				7213358821DA46A800CBE9E3 /* context */,
@@ -421,6 +430,7 @@
 		726196B321998C8B00730A67 /* W3C */ = {
 			isa = PBXGroup;
 			children = (
+				729BD0F4249D1FA1008025F0 /* events */,
 				72C677432469D15E00176D85 /* orientation */,
 				7246FB3A21DB3F94004CDA8F /* screenshot */,
 				7213358521DA460200CBE9E3 /* context */,
@@ -467,6 +477,24 @@
 				7252E19F21A29C4D000B5855 /* AppiumFuncTests.swift */,
 			);
 			path = AppiumDriver;
+			sourceTree = "<group>";
+		};
+		729BD0F4249D1FA1008025F0 /* events */ = {
+			isa = PBXGroup;
+			children = (
+				729BD0F2249D1F93008025F0 /* GetEvents.swift */,
+				729BD0EC249D0567008025F0 /* LogEvent.swift */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
+		72AE3D1A24A11BB300D242E3 /* events */ = {
+			isa = PBXGroup;
+			children = (
+				72AE3D18249F9E9F00D242E3 /* GetEventsTests.swift */,
+				729BD0EE249D113B008025F0 /* LogEventTest.swift */,
+			);
+			path = events;
 			sourceTree = "<group>";
 		};
 		72C0CDA82475CFF700657933 /* helpers */ = {
@@ -808,6 +836,7 @@
 				726196BD2199D67900730A67 /* Element.swift in Sources */,
 				726196C6219D35F700730A67 /* WebDriverError.swift in Sources */,
 				723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */,
+				729BD0F3249D1F93008025F0 /* GetEvents.swift in Sources */,
 				726196B52199BF9800730A67 /* CommandProtocol.swift in Sources */,
 				726196BF2199D75700730A67 /* Click.swift in Sources */,
 				726196B92199C28300730A67 /* FindElement.swift in Sources */,
@@ -817,6 +846,7 @@
 				726196A62195187F00730A67 /* driver.swift in Sources */,
 				7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */,
 				72686A9B21A1B3670042D385 /* GetCapabilities.swift in Sources */,
+				729BD0ED249D0567008025F0 /* LogEvent.swift in Sources */,
 				72C6773324696B3400176D85 /* GetScreenOrientation.swift in Sources */,
 				723673C5247E7654006009C8 /* GetLog.swift in Sources */,
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
@@ -859,8 +889,10 @@
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
 				72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */,
+				729BD0EF249D113B008025F0 /* LogEventTest.swift in Sources */,
 				72CA79642464085500988CDE /* TimeoutTests.swift in Sources */,
 				7252E1B521A4407A000B5855 /* ClickTests.swift in Sources */,
+				72AE3D19249F9E9F00D242E3 /* GetEventsTests.swift in Sources */,
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,
 				72C677362469717C00176D85 /* GetScreenOrientation.swift in Sources */,
 				7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */,

--- a/AppiumSwiftClient/command/CommandProtocol.swift
+++ b/AppiumSwiftClient/command/CommandProtocol.swift
@@ -44,3 +44,8 @@ public struct ValueOf<T: Decodable>: Decodable {
 enum DecodingError: Error {
     case decodingError(Error)
 }
+
+public enum WebDriverResult<T> {
+    case value(T)
+    case error(Error)
+}

--- a/AppiumSwiftClient/command/W3C/events/GetEvents.swift
+++ b/AppiumSwiftClient/command/W3C/events/GetEvents.swift
@@ -1,0 +1,72 @@
+//
+//  GetEvents.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 19.06.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias Events = WebDriverResult<EventsResult>
+struct W3CGetEvents: CommandProtocol {
+
+    private let command = W3CCommands.getEvents
+    private let sessionId: Session.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id) {
+        self.sessionId = sessionId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId)
+    }
+
+    func sendRequest() -> WebDriverResult<EventsResult> {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+        guard statusCode == 200 else {
+            print("Command Get Events failed for session \(sessionId) with Status Code: \(statusCode)")
+            return .error(WebDriverError(errorResult: returnData).raise())
+        }
+        // GF: This is ugly but still the most convienent way to return an object out of the Events endpoint response
+        do {
+            let jsonObj = try JSONSerialization.jsonObject(with: returnData, options: []) as? [String: [String: AnyObject]]
+            let eventsResult = jsonObj?["value"]?.reduce(into: EventsResult()) { result, key in
+                if key.key == "commands" {
+                    let commandArr = key.value as? [NSDictionary]
+                    commandArr?.forEach { command in
+                        result.commands.append(Command(cmd: command["cmd"] as! String, startTime: command["startTime"] as! Int, endTime: command["endTime"] as! Int))
+                    }
+                } else {
+                    result.events[key.key] = (key.value as! [Int])
+                }
+            }
+            guard eventsResult != nil else {
+                return .error(ParsingError.null)
+            }
+            return .value(eventsResult!)
+        } catch let error {
+            return .error(error)
+        }
+    }
+}
+
+enum ParsingError: Error {
+    case null
+}
+
+public struct EventsResult {
+    var commands: [Command]
+    var events: [String: [Int]]
+
+    init() {
+        self.commands = []
+        self.events = [String: [Int]]()
+    }
+}
+
+public struct Command: Decodable {
+    let cmd: String
+    let startTime: Int
+    let endTime: Int
+}

--- a/AppiumSwiftClient/command/W3C/events/LogEvent.swift
+++ b/AppiumSwiftClient/command/W3C/events/LogEvent.swift
@@ -1,0 +1,61 @@
+//
+//  LogEvent.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 19.06.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias LogEvent = Result<LogEventResponse, Error>
+public typealias LogEventResponse = String
+struct W3CLogEvent: CommandProtocol {
+
+    private let command = W3CCommands.logEvent
+    private let sessionId: Session.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id) {
+        self.sessionId = sessionId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId)
+    }
+
+    func sendRequest(vendorName: String, eventName: String) -> LogEvent {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl,
+                                         json: generateBodyData(vendorName: vendorName, eventName: eventName))
+        guard statusCode == 200 else {
+            print("Command Log Event \(eventName) with Vendor \(vendorName) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<LogEventResponse>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+
+    func generateBodyData(vendorName: String, eventName: String) -> Data {
+        let logEvent = CommandParam(vendor: vendorName, event: eventName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        do {
+            return try encoder.encode(logEvent)
+        } catch {
+            return "Invalid JSON".data(using: .utf8)!
+        }
+    }
+
+    fileprivate struct CommandParam: CommandParamProtocol {
+        let vendor: String
+        let event: String
+    
+        private enum CodingKeys: String, CodingKey {
+            case vendor, event
+        }
+    }
+}

--- a/AppiumSwiftClient/command/W3CCommands.swift
+++ b/AppiumSwiftClient/command/W3CCommands.swift
@@ -144,6 +144,8 @@ public struct W3CCommands {
 
     static let getAvailableLogTypes:    CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/log/types")
     static let getLog:                  CommandType = (HttpMethod.post,   "session/\(Id.session.rawValue)/log")
+    static let logEvent:                CommandType = (HttpMethod.post,   "session/\(Id.session.rawValue)/appium/log_event")
+    static let getEvents:               CommandType = (HttpMethod.post,   "session/\(Id.session.rawValue)/appium/events")
 
     // Common
     static let getAvailableContexts:    CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/contexts")

--- a/AppiumSwiftClient/common/driver.swift
+++ b/AppiumSwiftClient/common/driver.swift
@@ -34,6 +34,8 @@ protocol DriverProtocol {
     func getAvailableLogTypes() -> AvailableLogTypes
     func getLog(logType: String) -> Log
     func getServerLog() -> Log
+    func logEvent(with vendorName: String, and eventName: String) -> LogEvent
+    func getEvents() throws -> EventsResult
     func quit() -> EndSession
 }
 
@@ -196,6 +198,19 @@ public class AppiumDriver: DriverProtocol {
 
     public func getServerLog() -> Log {
         return getLog(logType: "server")
+    }
+
+    @discardableResult public func logEvent(with vendorName: String, and eventName: String) -> LogEvent {
+        return W3CLogEvent(sessionId: currentSession.id).sendRequest(vendorName: vendorName, eventName: eventName)
+    }
+
+    public func getEvents() throws -> EventsResult {
+        switch W3CGetEvents(sessionId: currentSession.id).sendRequest() {
+        case .value(let eventsResult):
+            return eventsResult
+        case .error(let error):
+            throw error
+        }
     }
 
     @discardableResult public func quit() -> EndSession {

--- a/AppiumSwiftClientUnitTests/command/W3C/events/GetEventsTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/events/GetEventsTests.swift
@@ -1,0 +1,129 @@
+//
+//  GetPageSourceTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 21.06.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetEventsTests: AppiumSwiftClientTestBase {
+    
+    private var url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/appium/events"
+    
+    func testGetEventsTest() {
+        let response = """
+            {
+              "value": {
+                "commands": [
+                  {
+                    "cmd": "logCustomEvent",
+                    "startTime": 1592746926635,
+                    "endTime": 1592746926635
+                  },
+                  {
+                    "cmd": "logCustomEvent",
+                    "startTime": 1592746929285,
+                    "endTime": 1592746929285
+                  },
+                  {
+                    "cmd": "logCustomEvent",
+                    "startTime": 1592746931355,
+                    "endTime": 1592746931356
+                  },
+                  {
+                    "cmd": "getLogEvents",
+                    "startTime": 1592746944221,
+                    "endTime": 1592746944221
+                  }
+                ],
+                "xcodeDetailsRetrieved": [
+                  1592746904176
+                ],
+                "appConfigured": [
+                  1592746904176
+                ],
+                "resetStarted": [
+                  1592746904176
+                ],
+                "resetComplete": [
+                  1592746904176
+                ],
+                "logCaptureStarted": [
+                  1592746904608
+                ],
+                "simStarted": [
+                  1592746904837
+                ],
+                "wdaStartAttempted": [
+                  1592746904963
+                ],
+                "wdaSessionAttempted": [
+                  1592746904967
+                ],
+                "wdaSessionStarted": [
+                  1592746905014
+                ],
+                "wdaStarted": [
+                  1592746905015
+                ],
+                "orientationSet": [
+                  1592746905015
+                ],
+                "appium:funEven": [
+                  1592746926635,
+                  1592746929285,
+                  1592746931355
+                ]
+              }
+            }
+        """.data(using: .utf8)!
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.post.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+        let driver = try! AppiumDriver(AppiumCapabilities(super.iOSOpts))
+        let events = try? driver.getEvents()
+        XCTAssert(events?.commands.count == 4)
+        XCTAssert(events?.events.count == 12)
+        XCTAssert(events?.events["appium:funEven"]?.count == 3)
+    }
+    
+    func testGetEventsTest2() {
+        let response = """
+            {
+              "value": {
+                "error": "invalid session id",
+                "message": "A session is either terminated or not started",
+                "stacktrace": "NoSuchDriverError: A session is either terminated or not started"
+              }
+            }
+        """.data(using: .utf8)!
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.post.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 500))
+        let driver = try! AppiumDriver(AppiumCapabilities(super.iOSOpts))
+        XCTAssertThrowsError(try driver.getEvents()) {
+            error in guard case WebDriverErrorEnum.invalidSessionIdError(error: let error) = error else {
+                return XCTFail()
+            }
+            XCTAssertEqual(error.error, "invalid session id")
+        }
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/events/LogEventTest.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/events/LogEventTest.swift
@@ -1,0 +1,35 @@
+//
+//  LogEventTest.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 19.06.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class LogEventTest: AppiumSwiftClientTestBase {
+    
+    private var url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/appium/log_event"
+    
+    func testCanLogCustomEvent() {
+        let response = """
+            {"value":""}
+        """.data(using: .utf8)!
+        
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.post.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+        let driver = try! AppiumDriver(AppiumCapabilities(super.iOSOpts))
+        XCTAssertNoThrow(try driver.logEvent(with: "funEvent", and: "appium").get())
+    }
+}


### PR DESCRIPTION
- Implements [LogEvents](https://appium.io/docs/en/commands/session/events/log-event/) and [GetEvents](https://appium.io/docs/en/commands/session/events/get-events/) endpoints along with respective unit and functional tests
- Adds a POC WebDriverResult enum and implements getEvents function at driver level using this abstraction. (Please let me know if this implementation is more on-par with what we previously discussed otherwise I will wipe it out of the codebase before removing the WIP status.)