### PR TITLE
feat: add appium prefix to non standard capabilities

### DIFF
--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -21,7 +21,8 @@ class AppiumFuncTests: XCTestCase {
         let opts = [
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
-            DesiredCapabilitiesEnum.app: "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
+            DesiredCapabilitiesEnum.app: "https://github.com/appium/ruby_lib_core/blob/master/test/functional/app/iOS13__UICatalog.app.zip?raw=true",
+//            "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
             DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"
@@ -223,7 +224,6 @@ class AppiumFuncTests: XCTestCase {
                 return XCTFail("should raise invalid element state error")
             }
             XCTAssertEqual("invalid element state", error.error)
-            XCTAssertTrue(error.message.contains("The on-screen keyboard must be present to send keys"))
         }
 
         let grayBtn = try! driver.findElement(by: .name, with: "Gray")
@@ -232,7 +232,6 @@ class AppiumFuncTests: XCTestCase {
                 return XCTFail("should raise invalid element state error")
             }
             XCTAssertEqual("invalid element state", error.error)
-            XCTAssertTrue(error.message.contains("The on-screen keyboard must be present to send keys"))
         }
     }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -21,8 +21,7 @@ class AppiumFuncTests: XCTestCase {
         let opts = [
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
-            DesiredCapabilitiesEnum.app: "https://github.com/appium/ruby_lib_core/blob/master/test/functional/app/iOS13__UICatalog.app.zip?raw=true",
-//            "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
+            DesiredCapabilitiesEnum.app: "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
             DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"

--- a/AppiumFuncTests/IOSDriver/LandscapeOrientationTest.swift
+++ b/AppiumFuncTests/IOSDriver/LandscapeOrientationTest.swift
@@ -16,7 +16,7 @@ class LandscapeOrientationTest: FunctionalBaseTest {
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
             DesiredCapabilitiesEnum.app: "com.apple.mobileslideshow",
-            DesiredCapabilitiesEnum.platformVersion: "13.4",
+            DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"
         ]

--- a/AppiumFuncTests/IOSDriver/PortraitOrientationTest.swift
+++ b/AppiumFuncTests/IOSDriver/PortraitOrientationTest.swift
@@ -16,7 +16,7 @@ class PortraitOrientationTest: FunctionalBaseTest {
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
             DesiredCapabilitiesEnum.app: "com.apple.mobileslideshow",
-            DesiredCapabilitiesEnum.platformVersion: "13.4",
+            DesiredCapabilitiesEnum.platformVersion: "13.5",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true",
             DesiredCapabilitiesEnum.orientation: ScreenOrientationEnum.landscape.rawValue

--- a/AppiumSwiftClient/command/W3C/CreateSession.swift
+++ b/AppiumSwiftClient/command/W3C/CreateSession.swift
@@ -50,9 +50,9 @@ struct W3CCreateSession: CommandProtocol {
         let oSSdesiredCapability = OssDesiredCapability(with: caps)
 
         let w3cDesiredCapability = W3CDesiredCapability(with: caps)
-        let w3cFirstMatch = W3CCapability(alwaysMatch: w3cDesiredCapability, firstMatch: [])
+        let capabilities = W3CCapability(alwaysMatch: w3cDesiredCapability, firstMatch: [])
 
-        let w3cCapability = CommandParam(desiredCapabilities: oSSdesiredCapability, capabilities: w3cFirstMatch)
+        let w3cCapability = CommandParam(desiredCapabilities: oSSdesiredCapability, capabilities: capabilities)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
 

--- a/AppiumSwiftClient/command/W3C/CreateSession.swift
+++ b/AppiumSwiftClient/command/W3C/CreateSession.swift
@@ -50,7 +50,7 @@ struct W3CCreateSession: CommandProtocol {
         let oSSdesiredCapability = OssDesiredCapability(with: caps)
 
         let w3cDesiredCapability = W3CDesiredCapability(with: caps)
-        let w3cFirstMatch = W3CFirstMatch(firstMatch: [w3cDesiredCapability])
+        let w3cFirstMatch = W3CCapability(alwaysMatch: w3cDesiredCapability, firstMatch: [])
 
         let w3cCapability = CommandParam(desiredCapabilities: oSSdesiredCapability, capabilities: w3cFirstMatch)
         let encoder = JSONEncoder()
@@ -65,10 +65,11 @@ struct W3CCreateSession: CommandProtocol {
 
     fileprivate struct CommandParam: CommandParamProtocol {
         let desiredCapabilities: OssDesiredCapability
-        let capabilities: W3CFirstMatch
+        let capabilities: W3CCapability
     }
 
-    fileprivate struct W3CFirstMatch: CommandParamProtocol {
+    fileprivate struct W3CCapability: CommandParamProtocol {
+        let alwaysMatch: W3CDesiredCapability
         let firstMatch: [W3CDesiredCapability]
     }
 }

--- a/AppiumSwiftClient/common/Capabilities.swift
+++ b/AppiumSwiftClient/common/Capabilities.swift
@@ -54,8 +54,14 @@ public struct W3CDesiredCapability: Codable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case platformName, automationName, platformVersion, deviceName, orientation
-        case app = "appium:app"
+        case platformName
+        case app = "appium:app",
+             reduceMotion = "appium:reduceMotion",
+             orientation = "appium:orientation",
+             automationName = "appium:automationName",
+             deviceName = "appium:deviceName",
+             platformVersion = "appium:platformVersion"
+
     }
 }
 

--- a/AppiumSwiftClientUnitTests/common/CapabilitiesTests.swift
+++ b/AppiumSwiftClientUnitTests/common/CapabilitiesTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import AppiumSwiftClient
 
 class CapabilitiesTest : XCTestCase {
-    func skip_testDefineCapabilities() {
+    func testDefineCapabilities() {
         let opts = [
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",


### PR DESCRIPTION
- Relaxed an assertion of `error.message.contains("The on-screen keyboard must be present to send keys")` since it could be different in appium versions
- Added `appium:` prefix (Will improve the logic later)
- Set AlwaysMatch in favour of FirstMatch. The FirstMatch is a blank