### PR TITLE
feat: Attributes endpoints

### DIFF
--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -267,4 +267,19 @@ class AppiumFuncTests: XCTestCase {
         let tagName = try? textFieldsScreen.roundedTextField().getTagName()
         XCTAssertEqual(tagName, "XCUIElementTypeTextField")
     }
+
+    func testCanGetButtonAttribute() {
+        let type = try? homeScreen.textFieldsBtn().getElementAttribute(with: "type")
+        let value = try? homeScreen.textFieldsBtn().getElementAttribute(with: "value")
+        let name = try? homeScreen.textFieldsBtn().getElementAttribute(with: "name")
+        let label = try? homeScreen.textFieldsBtn().getElementAttribute(with: "label")
+        let enabled = try? homeScreen.textFieldsBtn().getElementAttribute(with: "enabled")
+        let pageSourceAfterClear = try! driver.getPageSource().get()
+        XCTAssertEqual(type, "XCUIElementTypeStaticText")
+        XCTAssertEqual(value, "TextFields")
+        XCTAssertEqual(name, "TextFields")
+        XCTAssertEqual(label, "TextFields")
+        XCTAssertEqual(enabled, "true")
+        XCTAssertNotNil(type)
+    }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -15,6 +15,7 @@ class AppiumFuncTests: XCTestCase {
     var homeScreen: HomeScreen!
     var textFieldsScreen: TextFieldsScreen!
     var buttonsScreen: ButtonsScreen!
+    var segmentsScreen: SegmentsScreen!
 
     override func setUp() {
         let packageRootPath = URL(
@@ -25,7 +26,7 @@ class AppiumFuncTests: XCTestCase {
             DesiredCapabilitiesEnum.platformName: "iOS",
             DesiredCapabilitiesEnum.automationName: "xcuitest",
             DesiredCapabilitiesEnum.app: "\(packageRootPath)/AppiumFuncTests/app/UICatalog.app.zip",
-            DesiredCapabilitiesEnum.platformVersion: "13.5",
+            DesiredCapabilitiesEnum.platformVersion: "13.6",
             DesiredCapabilitiesEnum.deviceName: "iPhone 8",
             DesiredCapabilitiesEnum.reduceMotion: "true"
         ]
@@ -34,6 +35,7 @@ class AppiumFuncTests: XCTestCase {
             homeScreen = HomeScreen(driver)
             textFieldsScreen = TextFieldsScreen(driver)
             buttonsScreen = ButtonsScreen(driver)
+            segmentsScreen = SegmentsScreen(driver)
         } catch {
             XCTFail("Failed to spin up driver: \(error)")
         }
@@ -274,12 +276,16 @@ class AppiumFuncTests: XCTestCase {
         let name = try? homeScreen.textFieldsBtn().getElementAttribute(with: "name")
         let label = try? homeScreen.textFieldsBtn().getElementAttribute(with: "label")
         let enabled = try? homeScreen.textFieldsBtn().getElementAttribute(with: "enabled")
-        let pageSourceAfterClear = try! driver.getPageSource().get()
         XCTAssertEqual(type, "XCUIElementTypeStaticText")
         XCTAssertEqual(value, "TextFields")
         XCTAssertEqual(name, "TextFields")
         XCTAssertEqual(label, "TextFields")
         XCTAssertEqual(enabled, "true")
-        XCTAssertNotNil(type)
+    }
+
+    func testCanGetElementSelected() {
+        homeScreen.segmentsBtn().click()
+        XCTAssertFalse(try! segmentsScreen.checkBtn().isSelected())
+        XCTAssertTrue(try! segmentsScreen.searchBtn().isSelected())
     }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -306,4 +306,9 @@ class AppiumFuncTests: XCTestCase {
         let size = try? homeScreen.buttonsBtn().getElementSize()
         XCTAssertNotNil(size)
     }
+
+    func testCanGetElementRect() {
+        let rect = try? homeScreen.buttonsBtn().getElementRect()
+        XCTAssertNotNil(rect)
+    }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -298,7 +298,12 @@ class AppiumFuncTests: XCTestCase {
     }
 
     func testCanGetElementLocation() {
-        let point = try! homeScreen.buttonsBtn().getElementLocation()
+        let point = try? homeScreen.buttonsBtn().getElementLocation()
         XCTAssertNotNil(point)
+    }
+
+    func testCanGetElementSize() {
+        let size = try? homeScreen.buttonsBtn().getElementSize()
+        XCTAssertNotNil(size)
     }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -292,4 +292,8 @@ class AppiumFuncTests: XCTestCase {
     func testCanGetElementEnabled() {
         XCTAssertTrue(try! homeScreen.buttonsBtn().isEnabled())
     }
+
+    func testCanGetElementDisplayed() {
+        XCTAssertTrue(try! homeScreen.buttonsBtn().isDisplayed())
+    }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -12,7 +12,6 @@ import XCTest
 class AppiumFuncTests: XCTestCase {
 
     var driver: AppiumDriver!
-    
     var homeScreen: HomeScreen!
     var textFieldsScreen: TextFieldsScreen!
     var buttonsScreen: ButtonsScreen!
@@ -242,5 +241,19 @@ class AppiumFuncTests: XCTestCase {
         textFieldsScreen.roundedTextField().clear()
         let pageSourceAfterClear = try! driver.getPageSource().get()
         XCTAssertFalse(pageSourceAfterClear.contains(text))
+    }
+
+    func testCanGetButtonText() {
+        let text = try? homeScreen.buttonsBtn().getText()
+        XCTAssertEqual(text, "Buttons")
+    }
+
+    func testCanGetTextFromTextBox() {
+        homeScreen.textFieldsBtn().click()
+        let testText = "Test Text"
+        textFieldsScreen.roundedTextField().click()
+        textFieldsScreen.roundedTextField().sendKeys(with: testText)
+        let text = try? textFieldsScreen.roundedTextField().getText()
+        XCTAssertEqual(text, testText)
     }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -256,4 +256,15 @@ class AppiumFuncTests: XCTestCase {
         let text = try? textFieldsScreen.roundedTextField().getText()
         XCTAssertEqual(text, testText)
     }
+
+    func testCanGetButtonTagName() {
+        let tagName = try? homeScreen.buttonsBtn().getTagName()
+        XCTAssertEqual(tagName, "XCUIElementTypeStaticText")
+    }
+
+    func testCanGetTagNameOfTextBox() {
+        homeScreen.textFieldsBtn().click()
+        let tagName = try? textFieldsScreen.roundedTextField().getTagName()
+        XCTAssertEqual(tagName, "XCUIElementTypeTextField")
+    }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -288,4 +288,8 @@ class AppiumFuncTests: XCTestCase {
         XCTAssertFalse(try! segmentsScreen.checkBtn().isSelected())
         XCTAssertTrue(try! segmentsScreen.searchBtn().isSelected())
     }
+
+    func testCanGetElementEnabled() {
+        XCTAssertTrue(try! homeScreen.buttonsBtn().isEnabled())
+    }
 }

--- a/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
+++ b/AppiumFuncTests/AppiumDriver/AppiumFuncTests.swift
@@ -296,4 +296,9 @@ class AppiumFuncTests: XCTestCase {
     func testCanGetElementDisplayed() {
         XCTAssertTrue(try! homeScreen.buttonsBtn().isDisplayed())
     }
+
+    func testCanGetElementLocation() {
+        let point = try! homeScreen.buttonsBtn().getElementLocation()
+        XCTAssertNotNil(point)
+    }
 }

--- a/AppiumFuncTests/PageObjectModels/HomeScreen.swift
+++ b/AppiumFuncTests/PageObjectModels/HomeScreen.swift
@@ -24,4 +24,8 @@ struct HomeScreen {
     func buttonsBtn() -> MobileElement {
         return try! driver.findElement(by: .accessibilityId, with: "Buttons")
     }
+    
+    func segmentsBtn() -> MobileElement {
+        return try! driver.findElement(by: .accessibilityId, with: "Segments")
+    }
 }

--- a/AppiumFuncTests/PageObjectModels/HomeScreen.swift
+++ b/AppiumFuncTests/PageObjectModels/HomeScreen.swift
@@ -24,7 +24,7 @@ struct HomeScreen {
     func buttonsBtn() -> MobileElement {
         return try! driver.findElement(by: .accessibilityId, with: "Buttons")
     }
-    
+
     func segmentsBtn() -> MobileElement {
         return try! driver.findElement(by: .accessibilityId, with: "Segments")
     }

--- a/AppiumFuncTests/PageObjectModels/SegmentsScreen.swift
+++ b/AppiumFuncTests/PageObjectModels/SegmentsScreen.swift
@@ -1,0 +1,27 @@
+//
+//  SegmentsScreen.swift
+//  AppiumFuncTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+@testable import AppiumSwiftClient
+
+struct SegmentsScreen {
+
+    private var driver: AppiumDriver!
+
+    init(_ driver: AppiumDriver) {
+        self.driver = driver
+    }
+
+    func searchBtn() -> MobileElement {
+        return try! driver.findElement(by: .accessibilityId, with: "Search")
+    }
+
+    func checkBtn() -> MobileElement {
+        return try! driver.findElement(by: .accessibilityId, with: "Check")
+    }
+}

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		721AA00624B62F96008E5014 /* GetTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00524B62F96008E5014 /* GetTextTests.swift */; };
 		721AA00824B63281008E5014 /* GetTagName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00724B63281008E5014 /* GetTagName.swift */; };
 		721AA00A24B63581008E5014 /* GetTagNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00924B63581008E5014 /* GetTagNameTests.swift */; };
+		721AA00C24B63B4F008E5014 /* GetAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00B24B63B4F008E5014 /* GetAttribute.swift */; };
 		721D9CC724B10B9E0017A64A /* Clear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC624B10B9E0017A64A /* Clear.swift */; };
 		721D9CC924B1119C0017A64A /* ClearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC824B1119C0017A64A /* ClearTests.swift */; };
 		721D9CCD24B1F9800017A64A /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CCC24B1F9800017A64A /* HomeScreen.swift */; };
@@ -29,6 +30,7 @@
 		723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */; };
 		723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */; };
 		723673C5247E7654006009C8 /* GetLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723673C4247E7654006009C8 /* GetLog.swift */; };
+		723BF78F24BC6255009236FF /* GetElementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723BF78E24BC6255009236FF /* GetElementTests.swift */; };
 		7246FB3921DB3F10004CDA8F /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */; };
 		7246FB3C21DB3FA2004CDA8F /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */; };
 		7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */; };
@@ -144,6 +146,7 @@
 		721AA00524B62F96008E5014 /* GetTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTextTests.swift; sourceTree = "<group>"; };
 		721AA00724B63281008E5014 /* GetTagName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTagName.swift; sourceTree = "<group>"; };
 		721AA00924B63581008E5014 /* GetTagNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTagNameTests.swift; sourceTree = "<group>"; };
+		721AA00B24B63B4F008E5014 /* GetAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAttribute.swift; sourceTree = "<group>"; };
 		721D9CC624B10B9E0017A64A /* Clear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clear.swift; sourceTree = "<group>"; };
 		721D9CC824B1119C0017A64A /* ClearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearTests.swift; sourceTree = "<group>"; };
 		721D9CCC24B1F9800017A64A /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
@@ -152,6 +155,7 @@
 		723673C0247E5F13006009C8 /* GetAvailableLogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypes.swift; sourceTree = "<group>"; };
 		723673C2247E6ED1006009C8 /* GetAvailableLogTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAvailableLogTypesTests.swift; sourceTree = "<group>"; };
 		723673C4247E7654006009C8 /* GetLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLog.swift; sourceTree = "<group>"; };
+		723BF78E24BC6255009236FF /* GetElementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetElementTests.swift; sourceTree = "<group>"; };
 		7246FB3821DB3F10004CDA8F /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		7246FB3B21DB3FA2004CDA8F /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		7246FB3D21DCF81F004CDA8F /* W3CElementScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CElementScreenshot.swift; sourceTree = "<group>"; };
@@ -277,6 +281,7 @@
 				721D9CC624B10B9E0017A64A /* Clear.swift */,
 				721AA00324B5C1AC008E5014 /* GetText.swift */,
 				721AA00724B63281008E5014 /* GetTagName.swift */,
+				721AA00B24B63B4F008E5014 /* GetAttribute.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -577,6 +582,7 @@
 				721D9CC824B1119C0017A64A /* ClearTests.swift */,
 				721AA00524B62F96008E5014 /* GetTextTests.swift */,
 				721AA00924B63581008E5014 /* GetTagNameTests.swift */,
+				723BF78E24BC6255009236FF /* GetElementTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -910,6 +916,7 @@
 				729BD0ED249D0567008025F0 /* LogEvent.swift in Sources */,
 				72C6773324696B3400176D85 /* GetScreenOrientation.swift in Sources */,
 				723673C5247E7654006009C8 /* GetLog.swift in Sources */,
+				721AA00C24B63B4F008E5014 /* GetAttribute.swift in Sources */,
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
 				726196B02199790A00730A67 /* Method.swift in Sources */,
 				721AA00424B5C1AC008E5014 /* GetText.swift in Sources */,
@@ -953,6 +960,7 @@
 				723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */,
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
+				723BF78F24BC6255009236FF /* GetElementTests.swift in Sources */,
 				72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */,
 				721AA00A24B63581008E5014 /* GetTagNameTests.swift in Sources */,
 				729BD0EF249D113B008025F0 /* LogEventTest.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */; };
 		72051E8224C5F09000DDE840 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8124C5F09000DDE840 /* Size.swift */; };
 		72051E8424C5F36D00DDE840 /* ElementSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */; };
+		72051E8624C5F4A800DDE840 /* Rect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8524C5F4A800DDE840 /* Rect.swift */; };
+		72051E8824C5F79300DDE840 /* ElementRectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8724C5F79300DDE840 /* ElementRectTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -155,6 +157,8 @@
 		72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocationTests.swift; sourceTree = "<group>"; };
 		72051E8124C5F09000DDE840 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementSizeTests.swift; sourceTree = "<group>"; };
+		72051E8524C5F4A800DDE840 /* Rect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rect.swift; sourceTree = "<group>"; };
+		72051E8724C5F79300DDE840 /* ElementRectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementRectTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -309,6 +313,7 @@
 				72051E7924C59F1A00DDE840 /* Displayed.swift */,
 				72051E7D24C5A12600DDE840 /* Location.swift */,
 				72051E8124C5F09000DDE840 /* Size.swift */,
+				72051E8524C5F4A800DDE840 /* Rect.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -616,6 +621,7 @@
 				72051E7B24C5A08400DDE840 /* DisplayedTests.swift */,
 				72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */,
 				72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */,
+				72051E8724C5F79300DDE840 /* ElementRectTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -945,6 +951,7 @@
 				726196B92199C28300730A67 /* FindElement.swift in Sources */,
 				726196CB21A193CD00730A67 /* FindElementHelper.swift in Sources */,
 				726196B221997E4400730A67 /* Client.swift in Sources */,
+				72051E8624C5F4A800DDE840 /* Rect.swift in Sources */,
 				724BF8DD247530BE0008FA15 /* SetSettings.swift in Sources */,
 				726196A62195187F00730A67 /* driver.swift in Sources */,
 				7246FB3E21DCF81F004CDA8F /* W3CElementScreenshot.swift in Sources */,
@@ -1010,6 +1017,7 @@
 				72AE3D19249F9E9F00D242E3 /* GetEventsTests.swift in Sources */,
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,
 				72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */,
+				72051E8824C5F79300DDE840 /* ElementRectTests.swift in Sources */,
 				72C677362469717C00176D85 /* GetScreenOrientation.swift in Sources */,
 				72051E8424C5F36D00DDE840 /* ElementSizeTests.swift in Sources */,
 				7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358921DA46C900CBE9E3 /* CurrentContextTests.swift */; };
 		7213358C21DA47F700CBE9E3 /* SetContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358B21DA47F700CBE9E3 /* SetContextTests.swift */; };
 		7213358E21DA488200CBE9E3 /* SetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358D21DA488200CBE9E3 /* SetContext.swift */; };
+		721AA00424B5C1AC008E5014 /* GetText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00324B5C1AC008E5014 /* GetText.swift */; };
+		721AA00624B62F96008E5014 /* GetTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00524B62F96008E5014 /* GetTextTests.swift */; };
 		721D9CC724B10B9E0017A64A /* Clear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC624B10B9E0017A64A /* Clear.swift */; };
 		721D9CC924B1119C0017A64A /* ClearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC824B1119C0017A64A /* ClearTests.swift */; };
 		721D9CCD24B1F9800017A64A /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CCC24B1F9800017A64A /* HomeScreen.swift */; };
@@ -136,6 +138,8 @@
 		7213358921DA46C900CBE9E3 /* CurrentContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentContextTests.swift; sourceTree = "<group>"; };
 		7213358B21DA47F700CBE9E3 /* SetContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContextTests.swift; sourceTree = "<group>"; };
 		7213358D21DA488200CBE9E3 /* SetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContext.swift; sourceTree = "<group>"; };
+		721AA00324B5C1AC008E5014 /* GetText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetText.swift; sourceTree = "<group>"; };
+		721AA00524B62F96008E5014 /* GetTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTextTests.swift; sourceTree = "<group>"; };
 		721D9CC624B10B9E0017A64A /* Clear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clear.swift; sourceTree = "<group>"; };
 		721D9CC824B1119C0017A64A /* ClearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearTests.swift; sourceTree = "<group>"; };
 		721D9CCC24B1F9800017A64A /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
@@ -267,6 +271,7 @@
 				726196BE2199D75700730A67 /* Click.swift */,
 				72045A2424ACE887007B22A4 /* SendKeys.swift */,
 				721D9CC624B10B9E0017A64A /* Clear.swift */,
+				721AA00324B5C1AC008E5014 /* GetText.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -565,6 +570,7 @@
 				72045A2224ACE692007B22A4 /* SendKeysTests.swift */,
 				7252E1B421A4407A000B5855 /* ClickTests.swift */,
 				721D9CC824B1119C0017A64A /* ClearTests.swift */,
+				721AA00524B62F96008E5014 /* GetTextTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -900,6 +906,7 @@
 				723673C5247E7654006009C8 /* GetLog.swift in Sources */,
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
 				726196B02199790A00730A67 /* Method.swift in Sources */,
+				721AA00424B5C1AC008E5014 /* GetText.swift in Sources */,
 				720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */,
 				72C0CDB22475E35A00657933 /* AndroidDriver.swift in Sources */,
 				72C0CDAA2475D00A00657933 /* AnyValue.swift in Sources */,
@@ -926,6 +933,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				721AA00624B62F96008E5014 /* GetTextTests.swift in Sources */,
 				72E0FF4B24741D9500F6EE8A /* GetSettingsTest.swift in Sources */,
 				720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */,
 				72C677382469773300176D85 /* SetScreenOrientationTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7B24C5A08400DDE840 /* DisplayedTests.swift */; };
 		72051E7E24C5A12600DDE840 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7D24C5A12600DDE840 /* Location.swift */; };
 		72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */; };
+		72051E8224C5F09000DDE840 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8124C5F09000DDE840 /* Size.swift */; };
+		72051E8424C5F36D00DDE840 /* ElementSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -151,6 +153,8 @@
 		72051E7B24C5A08400DDE840 /* DisplayedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayedTests.swift; sourceTree = "<group>"; };
 		72051E7D24C5A12600DDE840 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocationTests.swift; sourceTree = "<group>"; };
+		72051E8124C5F09000DDE840 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
+		72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementSizeTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -304,6 +308,7 @@
 				72051E7524C59D2100DDE840 /* Enabled.swift */,
 				72051E7924C59F1A00DDE840 /* Displayed.swift */,
 				72051E7D24C5A12600DDE840 /* Location.swift */,
+				72051E8124C5F09000DDE840 /* Size.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -610,6 +615,7 @@
 				72051E7724C59E9C00DDE840 /* EnabledTests.swift */,
 				72051E7B24C5A08400DDE840 /* DisplayedTests.swift */,
 				72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */,
+				72051E8324C5F36D00DDE840 /* ElementSizeTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -969,6 +975,7 @@
 				72C6773C24698BFF00176D85 /* SetScreenOrientation.swift in Sources */,
 				728AAE0D2473F83900B2F8D8 /* GetSettings.swift in Sources */,
 				721D9CC724B10B9E0017A64A /* Clear.swift in Sources */,
+				72051E8224C5F09000DDE840 /* Size.swift in Sources */,
 				7246FB3C21DB3FA2004CDA8F /* Screenshot.swift in Sources */,
 				7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */,
 				72051E7E24C5A12600DDE840 /* Location.swift in Sources */,
@@ -1004,6 +1011,7 @@
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,
 				72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */,
 				72C677362469717C00176D85 /* GetScreenOrientation.swift in Sources */,
+				72051E8424C5F36D00DDE840 /* ElementSizeTests.swift in Sources */,
 				7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */,
 				72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */,
 				72045A2324ACE692007B22A4 /* SendKeysTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		72051E7824C59E9C00DDE840 /* EnabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7724C59E9C00DDE840 /* EnabledTests.swift */; };
 		72051E7A24C59F1A00DDE840 /* Displayed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7924C59F1A00DDE840 /* Displayed.swift */; };
 		72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7B24C5A08400DDE840 /* DisplayedTests.swift */; };
+		72051E7E24C5A12600DDE840 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7D24C5A12600DDE840 /* Location.swift */; };
+		72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -147,6 +149,8 @@
 		72051E7724C59E9C00DDE840 /* EnabledTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledTests.swift; sourceTree = "<group>"; };
 		72051E7924C59F1A00DDE840 /* Displayed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Displayed.swift; sourceTree = "<group>"; };
 		72051E7B24C5A08400DDE840 /* DisplayedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayedTests.swift; sourceTree = "<group>"; };
+		72051E7D24C5A12600DDE840 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocationTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -299,6 +303,7 @@
 				727DFD9124C4FF9200C6BCB4 /* Selected.swift */,
 				72051E7524C59D2100DDE840 /* Enabled.swift */,
 				72051E7924C59F1A00DDE840 /* Displayed.swift */,
+				72051E7D24C5A12600DDE840 /* Location.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -604,6 +609,7 @@
 				72051E7324C5087F00DDE840 /* SelectedTests.swift */,
 				72051E7724C59E9C00DDE840 /* EnabledTests.swift */,
 				72051E7B24C5A08400DDE840 /* DisplayedTests.swift */,
+				72051E7F24C5A7E300DDE840 /* ElementLocationTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -965,6 +971,7 @@
 				721D9CC724B10B9E0017A64A /* Clear.swift in Sources */,
 				7246FB3C21DB3FA2004CDA8F /* Screenshot.swift in Sources */,
 				7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */,
+				72051E7E24C5A12600DDE840 /* Location.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -995,6 +1002,7 @@
 				7252E1B521A4407A000B5855 /* ClickTests.swift in Sources */,
 				72AE3D19249F9E9F00D242E3 /* GetEventsTests.swift in Sources */,
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,
+				72051E8024C5A7E300DDE840 /* ElementLocationTests.swift in Sources */,
 				72C677362469717C00176D85 /* GetScreenOrientation.swift in Sources */,
 				7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */,
 				72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		72051E7424C5087F00DDE840 /* SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7324C5087F00DDE840 /* SelectedTests.swift */; };
 		72051E7624C59D2100DDE840 /* Enabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7524C59D2100DDE840 /* Enabled.swift */; };
 		72051E7824C59E9C00DDE840 /* EnabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7724C59E9C00DDE840 /* EnabledTests.swift */; };
+		72051E7A24C59F1A00DDE840 /* Displayed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7924C59F1A00DDE840 /* Displayed.swift */; };
+		72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7B24C5A08400DDE840 /* DisplayedTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -143,6 +145,8 @@
 		72051E7324C5087F00DDE840 /* SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedTests.swift; sourceTree = "<group>"; };
 		72051E7524C59D2100DDE840 /* Enabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enabled.swift; sourceTree = "<group>"; };
 		72051E7724C59E9C00DDE840 /* EnabledTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledTests.swift; sourceTree = "<group>"; };
+		72051E7924C59F1A00DDE840 /* Displayed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Displayed.swift; sourceTree = "<group>"; };
+		72051E7B24C5A08400DDE840 /* DisplayedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayedTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 				721AA00B24B63B4F008E5014 /* GetAttribute.swift */,
 				727DFD9124C4FF9200C6BCB4 /* Selected.swift */,
 				72051E7524C59D2100DDE840 /* Enabled.swift */,
+				72051E7924C59F1A00DDE840 /* Displayed.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -598,6 +603,7 @@
 				723BF78E24BC6255009236FF /* GetElementTests.swift */,
 				72051E7324C5087F00DDE840 /* SelectedTests.swift */,
 				72051E7724C59E9C00DDE840 /* EnabledTests.swift */,
+				72051E7B24C5A08400DDE840 /* DisplayedTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -920,6 +926,7 @@
 				726196C6219D35F700730A67 /* WebDriverError.swift in Sources */,
 				723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */,
 				72045A2524ACE887007B22A4 /* SendKeys.swift in Sources */,
+				72051E7A24C59F1A00DDE840 /* Displayed.swift in Sources */,
 				729BD0F3249D1F93008025F0 /* GetEvents.swift in Sources */,
 				726196B52199BF9800730A67 /* CommandProtocol.swift in Sources */,
 				726196BF2199D75700730A67 /* Click.swift in Sources */,
@@ -990,6 +997,7 @@
 				7252E19621A261AA000B5855 /* GetCapabilitiesTests.swift in Sources */,
 				72C677362469717C00176D85 /* GetScreenOrientation.swift in Sources */,
 				7213358A21DA46C900CBE9E3 /* CurrentContextTests.swift in Sources */,
+				72051E7C24C5A08400DDE840 /* DisplayedTests.swift in Sources */,
 				72045A2324ACE692007B22A4 /* SendKeysTests.swift in Sources */,
 				721D9CC924B1119C0017A64A /* ClearTests.swift in Sources */,
 				726196A4219499C400730A67 /* CapabilitiesTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		7213358E21DA488200CBE9E3 /* SetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358D21DA488200CBE9E3 /* SetContext.swift */; };
 		721AA00424B5C1AC008E5014 /* GetText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00324B5C1AC008E5014 /* GetText.swift */; };
 		721AA00624B62F96008E5014 /* GetTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00524B62F96008E5014 /* GetTextTests.swift */; };
+		721AA00824B63281008E5014 /* GetTagName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00724B63281008E5014 /* GetTagName.swift */; };
+		721AA00A24B63581008E5014 /* GetTagNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721AA00924B63581008E5014 /* GetTagNameTests.swift */; };
 		721D9CC724B10B9E0017A64A /* Clear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC624B10B9E0017A64A /* Clear.swift */; };
 		721D9CC924B1119C0017A64A /* ClearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CC824B1119C0017A64A /* ClearTests.swift */; };
 		721D9CCD24B1F9800017A64A /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721D9CCC24B1F9800017A64A /* HomeScreen.swift */; };
@@ -140,6 +142,8 @@
 		7213358D21DA488200CBE9E3 /* SetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetContext.swift; sourceTree = "<group>"; };
 		721AA00324B5C1AC008E5014 /* GetText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetText.swift; sourceTree = "<group>"; };
 		721AA00524B62F96008E5014 /* GetTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTextTests.swift; sourceTree = "<group>"; };
+		721AA00724B63281008E5014 /* GetTagName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTagName.swift; sourceTree = "<group>"; };
+		721AA00924B63581008E5014 /* GetTagNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTagNameTests.swift; sourceTree = "<group>"; };
 		721D9CC624B10B9E0017A64A /* Clear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clear.swift; sourceTree = "<group>"; };
 		721D9CC824B1119C0017A64A /* ClearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearTests.swift; sourceTree = "<group>"; };
 		721D9CCC24B1F9800017A64A /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
@@ -272,6 +276,7 @@
 				72045A2424ACE887007B22A4 /* SendKeys.swift */,
 				721D9CC624B10B9E0017A64A /* Clear.swift */,
 				721AA00324B5C1AC008E5014 /* GetText.swift */,
+				721AA00724B63281008E5014 /* GetTagName.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -571,6 +576,7 @@
 				7252E1B421A4407A000B5855 /* ClickTests.swift */,
 				721D9CC824B1119C0017A64A /* ClearTests.swift */,
 				721AA00524B62F96008E5014 /* GetTextTests.swift */,
+				721AA00924B63581008E5014 /* GetTagNameTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -907,6 +913,7 @@
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
 				726196B02199790A00730A67 /* Method.swift in Sources */,
 				721AA00424B5C1AC008E5014 /* GetText.swift in Sources */,
+				721AA00824B63281008E5014 /* GetTagName.swift in Sources */,
 				720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */,
 				72C0CDB22475E35A00657933 /* AndroidDriver.swift in Sources */,
 				72C0CDAA2475D00A00657933 /* AnyValue.swift in Sources */,
@@ -947,6 +954,7 @@
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
 				72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */,
+				721AA00A24B63581008E5014 /* GetTagNameTests.swift in Sources */,
 				729BD0EF249D113B008025F0 /* LogEventTest.swift in Sources */,
 				72CA79642464085500988CDE /* TimeoutTests.swift in Sources */,
 				7252E1B521A4407A000B5855 /* ClickTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		72045A2324ACE692007B22A4 /* SendKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72045A2224ACE692007B22A4 /* SendKeysTests.swift */; };
 		72045A2524ACE887007B22A4 /* SendKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72045A2424ACE887007B22A4 /* SendKeys.swift */; };
+		72051E7224C5055000DDE840 /* SegmentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7124C5055000DDE840 /* SegmentsScreen.swift */; };
+		72051E7424C5087F00DDE840 /* SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7324C5087F00DDE840 /* SelectedTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -69,6 +71,7 @@
 		726196CB21A193CD00730A67 /* FindElementHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726196CA21A193CD00730A67 /* FindElementHelper.swift */; };
 		72686A9B21A1B3670042D385 /* GetCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72686A9A21A1B3670042D385 /* GetCapabilities.swift */; };
 		7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7271E74D245C8CBE0019F6DD /* EndSessionTests.swift */; };
+		727DFD9224C4FF9200C6BCB4 /* Selected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727DFD9124C4FF9200C6BCB4 /* Selected.swift */; };
 		728AAE0D2473F83900B2F8D8 /* GetSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728AAE0C2473F83900B2F8D8 /* GetSettings.swift */; };
 		728DD59C2461A665004E6800 /* GoBack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59B2461A665004E6800 /* GoBack.swift */; };
 		728DD5A02461DF6E004E6800 /* GoBackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DD59F2461DF6E004E6800 /* GoBackTest.swift */; };
@@ -134,6 +137,8 @@
 		6B597A9FB3F011F41EC81483 /* Pods-AppiumFuncTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppiumFuncTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AppiumFuncTests/Pods-AppiumFuncTests.release.xcconfig"; sourceTree = "<group>"; };
 		72045A2224ACE692007B22A4 /* SendKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKeysTests.swift; sourceTree = "<group>"; };
 		72045A2424ACE887007B22A4 /* SendKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKeys.swift; sourceTree = "<group>"; };
+		72051E7124C5055000DDE840 /* SegmentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentsScreen.swift; sourceTree = "<group>"; };
+		72051E7324C5087F00DDE840 /* SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -197,6 +202,7 @@
 		726196CA21A193CD00730A67 /* FindElementHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindElementHelper.swift; sourceTree = "<group>"; };
 		72686A9A21A1B3670042D385 /* GetCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCapabilities.swift; sourceTree = "<group>"; };
 		7271E74D245C8CBE0019F6DD /* EndSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndSessionTests.swift; sourceTree = "<group>"; };
+		727DFD9124C4FF9200C6BCB4 /* Selected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selected.swift; sourceTree = "<group>"; };
 		728AAE0C2473F83900B2F8D8 /* GetSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSettings.swift; sourceTree = "<group>"; };
 		728DD59B2461A665004E6800 /* GoBack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBack.swift; sourceTree = "<group>"; };
 		728DD59F2461DF6E004E6800 /* GoBackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBackTest.swift; sourceTree = "<group>"; };
@@ -282,6 +288,7 @@
 				721AA00324B5C1AC008E5014 /* GetText.swift */,
 				721AA00724B63281008E5014 /* GetTagName.swift */,
 				721AA00B24B63B4F008E5014 /* GetAttribute.swift */,
+				727DFD9124C4FF9200C6BCB4 /* Selected.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -383,6 +390,7 @@
 				721D9CD024B200940017A64A /* ButtonsScreen.swift */,
 				721D9CCE24B1FD370017A64A /* TextFieldsScreen.swift */,
 				721D9CCC24B1F9800017A64A /* HomeScreen.swift */,
+				72051E7124C5055000DDE840 /* SegmentsScreen.swift */,
 			);
 			path = PageObjectModels;
 			sourceTree = "<group>";
@@ -583,6 +591,7 @@
 				721AA00524B62F96008E5014 /* GetTextTests.swift */,
 				721AA00924B63581008E5014 /* GetTagNameTests.swift */,
 				723BF78E24BC6255009236FF /* GetElementTests.swift */,
+				72051E7324C5087F00DDE840 /* SelectedTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -884,6 +893,7 @@
 				72C0CDAC2475DE1E00657933 /* IOSDriverTests.swift in Sources */,
 				721D9CCD24B1F9800017A64A /* HomeScreen.swift in Sources */,
 				721D9CCF24B1FD370017A64A /* TextFieldsScreen.swift in Sources */,
+				72051E7224C5055000DDE840 /* SegmentsScreen.swift in Sources */,
 				72C677422469CE8D00176D85 /* PortraitOrientationTest.swift in Sources */,
 				721D9CD124B200940017A64A /* ButtonsScreen.swift in Sources */,
 				72C677402469C9C100176D85 /* FunctionalBaseTest.swift in Sources */,
@@ -919,6 +929,7 @@
 				721AA00C24B63B4F008E5014 /* GetAttribute.swift in Sources */,
 				726196C1219A993E00730A67 /* WebDriverErrorEnum.swift in Sources */,
 				726196B02199790A00730A67 /* Method.swift in Sources */,
+				727DFD9224C4FF9200C6BCB4 /* Selected.swift in Sources */,
 				721AA00424B5C1AC008E5014 /* GetText.swift in Sources */,
 				721AA00824B63281008E5014 /* GetTagName.swift in Sources */,
 				720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */,
@@ -957,6 +968,7 @@
 				7213358421DA284B00CBE9E3 /* AvailableContextsTests.swift in Sources */,
 				726196962194948900730A67 /* AppiumSwiftClientUnitTests.swift in Sources */,
 				7252E19421A260EC000B5855 /* AppiumSwiftClientTestBase.swift in Sources */,
+				72051E7424C5087F00DDE840 /* SelectedTests.swift in Sources */,
 				723673C3247E6ED1006009C8 /* GetAvailableLogTypesTests.swift in Sources */,
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,

--- a/AppiumSwiftClient.xcodeproj/project.pbxproj
+++ b/AppiumSwiftClient.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		72045A2524ACE887007B22A4 /* SendKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72045A2424ACE887007B22A4 /* SendKeys.swift */; };
 		72051E7224C5055000DDE840 /* SegmentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7124C5055000DDE840 /* SegmentsScreen.swift */; };
 		72051E7424C5087F00DDE840 /* SelectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7324C5087F00DDE840 /* SelectedTests.swift */; };
+		72051E7624C59D2100DDE840 /* Enabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7524C59D2100DDE840 /* Enabled.swift */; };
+		72051E7824C59E9C00DDE840 /* EnabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72051E7724C59E9C00DDE840 /* EnabledTests.swift */; };
 		720CA7FA2460613900D85732 /* GetPageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7F92460613900D85732 /* GetPageSource.swift */; };
 		720CA7FE2460737100D85732 /* GetPageSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720CA7FD2460737100D85732 /* GetPageSourceTest.swift */; };
 		7213358221DA25CD00CBE9E3 /* AvailableContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */; };
@@ -139,6 +141,8 @@
 		72045A2424ACE887007B22A4 /* SendKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKeys.swift; sourceTree = "<group>"; };
 		72051E7124C5055000DDE840 /* SegmentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentsScreen.swift; sourceTree = "<group>"; };
 		72051E7324C5087F00DDE840 /* SelectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedTests.swift; sourceTree = "<group>"; };
+		72051E7524C59D2100DDE840 /* Enabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enabled.swift; sourceTree = "<group>"; };
+		72051E7724C59E9C00DDE840 /* EnabledTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledTests.swift; sourceTree = "<group>"; };
 		720CA7F92460613900D85732 /* GetPageSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSource.swift; sourceTree = "<group>"; };
 		720CA7FD2460737100D85732 /* GetPageSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageSourceTest.swift; sourceTree = "<group>"; };
 		7213358121DA25CD00CBE9E3 /* AvailableContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableContexts.swift; sourceTree = "<group>"; };
@@ -289,6 +293,7 @@
 				721AA00724B63281008E5014 /* GetTagName.swift */,
 				721AA00B24B63B4F008E5014 /* GetAttribute.swift */,
 				727DFD9124C4FF9200C6BCB4 /* Selected.swift */,
+				72051E7524C59D2100DDE840 /* Enabled.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -592,6 +597,7 @@
 				721AA00924B63581008E5014 /* GetTagNameTests.swift */,
 				723BF78E24BC6255009236FF /* GetElementTests.swift */,
 				72051E7324C5087F00DDE840 /* SelectedTests.swift */,
+				72051E7724C59E9C00DDE840 /* EnabledTests.swift */,
 			);
 			path = element;
 			sourceTree = "<group>";
@@ -909,6 +915,7 @@
 				726196B72199C1C900730A67 /* SearchContext.swift in Sources */,
 				72C0CDB02475E2FF00657933 /* IOSDriver.swift in Sources */,
 				728DD59C2461A665004E6800 /* GoBack.swift in Sources */,
+				72051E7624C59D2100DDE840 /* Enabled.swift in Sources */,
 				726196BD2199D67900730A67 /* Element.swift in Sources */,
 				726196C6219D35F700730A67 /* WebDriverError.swift in Sources */,
 				723673C1247E5F13006009C8 /* GetAvailableLogTypes.swift in Sources */,
@@ -973,6 +980,7 @@
 				7271E74E245C8CBE0019F6DD /* EndSessionTests.swift in Sources */,
 				7252E1B321A43C96000B5855 /* FindElementsTests.swift in Sources */,
 				723BF78F24BC6255009236FF /* GetElementTests.swift in Sources */,
+				72051E7824C59E9C00DDE840 /* EnabledTests.swift in Sources */,
 				72F2ADB52481158D0017B51B /* GetLogTests.swift in Sources */,
 				721AA00A24B63581008E5014 /* GetTagNameTests.swift in Sources */,
 				729BD0EF249D113B008025F0 /* LogEventTest.swift in Sources */,

--- a/AppiumSwiftClient/command/W3C/element/Displayed.swift
+++ b/AppiumSwiftClient/command/W3C/element/Displayed.swift
@@ -1,5 +1,5 @@
 //
-//  Enabled.swift
+//  Displayed.swift
 //  AppiumSwiftClient
 //
 //  Created by Gabriel Fioretti on 20.07.20.
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public typealias ElementEnabled = Result<Bool, Error>
-struct W3CElementEnabled: CommandProtocol {
+public typealias ElementDisplayed = Result<Bool, Error>
+struct W3CElementDisplayed: CommandProtocol {
 
-    private let command = W3CCommands.isElementEnabled
+    private let command = W3CCommands.isElementDisplayed
     private let sessionId: Session.Id
     private let elementId: MobileElement.Id
     private let commandUrl: W3CCommands.CommandPath
@@ -22,13 +22,13 @@ struct W3CElementEnabled: CommandProtocol {
         self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
     }
 
-    func sendRequest() -> ElementEnabled {
+    func sendRequest() -> ElementDisplayed {
         let (statusCode, returnData) =
             HttpClient().sendSyncRequest(method: command.0,
                                          commandPath: commandUrl)
 
         guard statusCode == 200 else {
-            print("Command Element Enabled of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            print("Command Element Displayed of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
             return .failure(WebDriverError(errorResult: returnData).raise())
         }
         do {

--- a/AppiumSwiftClient/command/W3C/element/Enabled.swift
+++ b/AppiumSwiftClient/command/W3C/element/Enabled.swift
@@ -1,0 +1,41 @@
+//
+//  Enabled.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementEnabled = Result<Bool, Error>
+struct W3CElementEnabled: CommandProtocol {
+
+    private let command = W3CCommands.isElementEnabled
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
+    }
+
+    func sendRequest() -> ElementSelected {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+
+        guard statusCode == 200 else {
+            print("Command Element Enabled of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<Bool>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/GetAttribute.swift
+++ b/AppiumSwiftClient/command/W3C/element/GetAttribute.swift
@@ -1,0 +1,39 @@
+//
+//  GetAttribute.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 08.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementAttribute = Result<String, Error>
+struct W3CGetElementAttribute: CommandProtocol {
+
+    private let command = W3CCommands.getElementAttribute
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+    }
+
+    func sendRequest(attribute: String) -> ElementAttribute {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: W3CCommands().url(for: command, with: sessionId, and: elementId, and: attribute))
+
+        guard statusCode == 200 else {
+            print("Command Get Attibute \(attribute) of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<String>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/GetTagName.swift
+++ b/AppiumSwiftClient/command/W3C/element/GetTagName.swift
@@ -1,5 +1,5 @@
 //
-//  GetText.swift
+//  GetTagName.swift
 //  AppiumSwiftClient
 //
 //  Created by Gabriel Fioretti on 08.07.20.
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public typealias ElementText = Result<String, Error>
-struct W3CGetElementText: CommandProtocol {
+public typealias ElementTagName = Result<String, Error>
+struct W3CGetElementTagName: CommandProtocol {
 
-    private let command = W3CCommands.getElementText
+    private let command = W3CCommands.getElementTagName
     private let sessionId: Session.Id
     private let elementId: MobileElement.Id
     private let commandUrl: W3CCommands.CommandPath
@@ -22,13 +22,13 @@ struct W3CGetElementText: CommandProtocol {
         self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
     }
 
-    func sendRequest() -> ElementText {
+    func sendRequest() -> ElementTagName {
         let (statusCode, returnData) =
             HttpClient().sendSyncRequest(method: command.0,
                                          commandPath: commandUrl)
 
         guard statusCode == 200 else {
-            print("Command Get Text of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            print("Command Get Tag Name of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
             return .failure(WebDriverError(errorResult: returnData).raise())
         }
         do {

--- a/AppiumSwiftClient/command/W3C/element/GetText.swift
+++ b/AppiumSwiftClient/command/W3C/element/GetText.swift
@@ -1,0 +1,41 @@
+//
+//  GetText.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 08.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementText = Result<String, Error>
+struct W3CGetElementText: CommandProtocol {
+
+    private let command = W3CCommands.getElementText
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+    private let commandUrl: W3CCommands.CommandPath
+    
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
+    }
+    
+    func sendRequest() -> ElementText {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+
+        guard statusCode == 200 else {
+            print("Command Get Text of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<String>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/Location.swift
+++ b/AppiumSwiftClient/command/W3C/element/Location.swift
@@ -1,0 +1,51 @@
+//
+//  Location.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementLocation = Result<Point, Error>
+struct W3CElementLocation: CommandProtocol {
+
+    private let command = W3CCommands.getElementLocation
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
+    }
+
+    func sendRequest() -> ElementLocation {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+
+        guard statusCode == 200 else {
+            print("Command Element Displayed of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<Point>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}
+
+public struct Point: Decodable {
+    let xCoord: Int
+    let yCoord: Int
+
+    enum CodingKeys: String, CodingKey {
+        case xCoord = "x"
+        case yCoord = "y"
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/Rect.swift
+++ b/AppiumSwiftClient/command/W3C/element/Rect.swift
@@ -1,0 +1,54 @@
+//
+//  Rect.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementRect = Result<Rect, Error>
+struct W3CElementRect: CommandProtocol {
+
+    private let command = W3CCommands.getElementRect
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
+    }
+
+    func sendRequest() -> ElementRect {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+
+        guard statusCode == 200 else {
+            print("Command Element Rect of \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<Rect>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}
+
+public struct Rect: Decodable {
+    let width: Int
+    let height: Int
+    let xCoord: Int
+    let yCoord: Int
+
+    enum CodingKeys: String, CodingKey {
+        case xCoord = "x"
+        case yCoord = "y"
+        case width, height
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/Selected.swift
+++ b/AppiumSwiftClient/command/W3C/element/Selected.swift
@@ -1,0 +1,41 @@
+//
+//  Selected.swift
+//  AppiumSwiftClient
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+
+public typealias ElementSelected = Result<Bool, Error>
+struct W3CElementSelected: CommandProtocol {
+
+    private let command = W3CCommands.isElementSelected
+    private let sessionId: Session.Id
+    private let elementId: MobileElement.Id
+    private let commandUrl: W3CCommands.CommandPath
+
+    init(sessionId: Session.Id, elementId: MobileElement.Id) {
+        self.sessionId = sessionId
+        self.elementId = elementId
+        self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
+    }
+
+    func sendRequest() -> ElementSelected {
+        let (statusCode, returnData) =
+            HttpClient().sendSyncRequest(method: command.0,
+                                         commandPath: commandUrl)
+
+        guard statusCode == 200 else {
+            print("Command Element Selected of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            return .failure(WebDriverError(errorResult: returnData).raise())
+        }
+        do {
+            let response = try JSONDecoder().decode(ValueOf<Bool>.self, from: returnData).value
+            return .success(response)
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/AppiumSwiftClient/command/W3C/element/Size.swift
+++ b/AppiumSwiftClient/command/W3C/element/Size.swift
@@ -1,5 +1,5 @@
 //
-//  Location.swift
+//  Size.swift
 //  AppiumSwiftClient
 //
 //  Created by Gabriel Fioretti on 20.07.20.
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public typealias ElementLocation = Result<Point, Error>
-struct W3CElementLocation: CommandProtocol {
+public typealias ElementSize = Result<Dimension, Error>
+struct W3CElementSize: CommandProtocol {
 
-    private let command = W3CCommands.getElementLocation
+    private let command = W3CCommands.getElementSize
     private let sessionId: Session.Id
     private let elementId: MobileElement.Id
     private let commandUrl: W3CCommands.CommandPath
@@ -22,17 +22,17 @@ struct W3CElementLocation: CommandProtocol {
         self.commandUrl = W3CCommands().url(for: command, with: sessionId, and: elementId)
     }
 
-    func sendRequest() -> ElementLocation {
+    func sendRequest() -> ElementSize {
         let (statusCode, returnData) =
             HttpClient().sendSyncRequest(method: command.0,
                                          commandPath: commandUrl)
 
         guard statusCode == 200 else {
-            print("Command Element Location of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
+            print("Command Element Size of Element \(elementId) Failed for \(sessionId) with Status Code: \(statusCode)")
             return .failure(WebDriverError(errorResult: returnData).raise())
         }
         do {
-            let response = try JSONDecoder().decode(ValueOf<Point>.self, from: returnData).value
+            let response = try JSONDecoder().decode(ValueOf<Dimension>.self, from: returnData).value
             return .success(response)
         } catch let error {
             return .failure(error)
@@ -40,12 +40,7 @@ struct W3CElementLocation: CommandProtocol {
     }
 }
 
-public struct Point: Decodable {
-    let xCoord: Int
-    let yCoord: Int
-
-    enum CodingKeys: String, CodingKey {
-        case xCoord = "x"
-        case yCoord = "y"
-    }
+public struct Dimension: Decodable {
+    let width: Int
+    let height: Int
 }

--- a/AppiumSwiftClient/command/W3C/events/LogEvent.swift
+++ b/AppiumSwiftClient/command/W3C/events/LogEvent.swift
@@ -53,7 +53,7 @@ struct W3CLogEvent: CommandProtocol {
     fileprivate struct CommandParam: CommandParamProtocol {
         let vendor: String
         let event: String
-    
+
         private enum CodingKeys: String, CodingKey {
             case vendor, event
         }

--- a/AppiumSwiftClient/command/W3CCommands.swift
+++ b/AppiumSwiftClient/command/W3CCommands.swift
@@ -25,10 +25,11 @@ public struct W3CCommands {
     /**
      Get a path of W3CCommands with given session id and element id.
     **/
-    func url(for urlBase: CommandType, with sessionId: Session.Id = "", and elementId: MobileElement.Id = "") -> W3CCommands.CommandPath {
+    func url(for urlBase: CommandType, with sessionId: Session.Id = "", and elementId: MobileElement.Id = "", and attributeName: String = "") -> W3CCommands.CommandPath {
         let commandUrl = urlBase.1
             .replacingOccurrences(of: W3CCommands.Id.session.rawValue, with: sessionId)
             .replacingOccurrences(of: W3CCommands.Id.element.rawValue, with: elementId)
+            .replacingOccurrences(of: W3CCommands.Attribute.name.rawValue, with: attributeName)
         return commandUrl
     }
 

--- a/AppiumSwiftClient/command/W3CCommands.swift
+++ b/AppiumSwiftClient/command/W3CCommands.swift
@@ -76,6 +76,7 @@ public struct W3CCommands {
     static let getElementTagName:       CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/name")
     static let getElementRect:          CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/rect")
     static let getElementLocation:      CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/location")
+    static let getElementSize:          CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/size")
     static let isElementEnabled:        CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/enabled")
 
     // Document Handling

--- a/AppiumSwiftClient/command/W3CCommands.swift
+++ b/AppiumSwiftClient/command/W3CCommands.swift
@@ -75,6 +75,7 @@ public struct W3CCommands {
     static let getElementText:          CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/text")
     static let getElementTagName:       CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/name")
     static let getElementRect:          CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/rect")
+    static let getElementLocation:      CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/location")
     static let isElementEnabled:        CommandType = (HttpMethod.get,    "session/\(Id.session.rawValue)/element/\(Id.element.rawValue)/enabled")
 
     // Document Handling

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -18,6 +18,7 @@ protocol Element {
     func getTagName() throws -> String
     func getElementAttribute(with attributeName: String) throws -> String
     func isSelected() throws -> Bool
+    func isEnabled() throws -> Bool
 }
 
 public struct MobileElement: Element {
@@ -79,5 +80,9 @@ public struct MobileElement: Element {
 
     public func isSelected() throws -> Bool {
         return try W3CElementSelected(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func isEnabled() throws -> Bool {
+        return try W3CElementEnabled(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -21,6 +21,7 @@ protocol Element {
     func isEnabled() throws -> Bool
     func isDisplayed() throws -> Bool
     func getElementLocation() throws -> Point
+    func getElementSize() throws -> Dimension
 }
 
 public struct MobileElement: Element {
@@ -94,5 +95,9 @@ public struct MobileElement: Element {
 
     public func getElementLocation() throws -> Point {
         return try W3CElementLocation(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func getElementSize() throws -> Dimension {
+        return try W3CElementSize(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -22,6 +22,7 @@ protocol Element {
     func isDisplayed() throws -> Bool
     func getElementLocation() throws -> Point
     func getElementSize() throws -> Dimension
+    func getElementRect() throws -> Rect
 }
 
 public struct MobileElement: Element {
@@ -99,5 +100,9 @@ public struct MobileElement: Element {
 
     public func getElementSize() throws -> Dimension {
         return try W3CElementSize(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func getElementRect() throws -> Rect {
+        return try W3CElementRect(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -16,6 +16,7 @@ protocol Element {
     func clear() -> Clear
     func getText() throws -> String
     func getTagName() throws -> String
+    func getElementAttribute(with attributeName: String) throws -> String
 }
 
 public struct MobileElement: Element {
@@ -69,5 +70,9 @@ public struct MobileElement: Element {
 
     public func getTagName() throws -> String {
         return try W3CGetElementTagName(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func getElementAttribute(with attributeName: String) throws -> String {
+        return try W3CGetElementAttribute(sessionId: sessionId, elementId: id).sendRequest(attribute: attributeName).get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -17,6 +17,7 @@ protocol Element {
     func getText() throws -> String
     func getTagName() throws -> String
     func getElementAttribute(with attributeName: String) throws -> String
+    func isSelected() throws -> Bool
 }
 
 public struct MobileElement: Element {
@@ -74,5 +75,9 @@ public struct MobileElement: Element {
 
     public func getElementAttribute(with attributeName: String) throws -> String {
         return try W3CGetElementAttribute(sessionId: sessionId, elementId: id).sendRequest(attribute: attributeName).get()
+    }
+
+    public func isSelected() throws -> Bool {
+        return try W3CElementSelected(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -20,6 +20,7 @@ protocol Element {
     func isSelected() throws -> Bool
     func isEnabled() throws -> Bool
     func isDisplayed() throws -> Bool
+    func getElementLocation() throws -> Point
 }
 
 public struct MobileElement: Element {
@@ -89,5 +90,9 @@ public struct MobileElement: Element {
 
     public func isDisplayed() throws -> Bool {
         return try W3CElementDisplayed(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func getElementLocation() throws -> Point {
+        return try W3CElementLocation(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -19,6 +19,7 @@ protocol Element {
     func getElementAttribute(with attributeName: String) throws -> String
     func isSelected() throws -> Bool
     func isEnabled() throws -> Bool
+    func isDisplayed() throws -> Bool
 }
 
 public struct MobileElement: Element {
@@ -84,5 +85,9 @@ public struct MobileElement: Element {
 
     public func isEnabled() throws -> Bool {
         return try W3CElementEnabled(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func isDisplayed() throws -> Bool {
+        return try W3CElementDisplayed(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -14,6 +14,7 @@ protocol Element {
     func getBase64Screenshot() -> TakeScreenshot
     func sendKeys(with text: String) -> SendKeys
     func clear() -> Clear
+    func getText() throws -> String
 }
 
 public struct MobileElement: Element {
@@ -59,5 +60,9 @@ public struct MobileElement: Element {
 
     @discardableResult public func clear() -> Clear {
         return W3CElementClear(sessionId: sessionId, elementId: id).sendRequest()
+    }
+    
+    public func getText() throws -> String {
+        return try W3CGetElementText(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClient/common/Element.swift
+++ b/AppiumSwiftClient/common/Element.swift
@@ -15,6 +15,7 @@ protocol Element {
     func sendKeys(with text: String) -> SendKeys
     func clear() -> Clear
     func getText() throws -> String
+    func getTagName() throws -> String
 }
 
 public struct MobileElement: Element {
@@ -61,8 +62,12 @@ public struct MobileElement: Element {
     @discardableResult public func clear() -> Clear {
         return W3CElementClear(sessionId: sessionId, elementId: id).sendRequest()
     }
-    
+
     public func getText() throws -> String {
         return try W3CGetElementText(sessionId: sessionId, elementId: id).sendRequest().get()
+    }
+
+    public func getTagName() throws -> String {
+        return try W3CGetElementTagName(sessionId: sessionId, elementId: id).sendRequest().get()
     }
 }

--- a/AppiumSwiftClientUnitTests/command/W3C/element/DisplayedTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/DisplayedTests.swift
@@ -1,0 +1,37 @@
+//
+//  DisplayedTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class DisplayedTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/displayed"
+    
+    func testElementDisplayed() {
+        let response = """
+            {"value":true}
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertTrue(try! element.isDisplayed())
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/ElementLocationTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/ElementLocationTests.swift
@@ -1,0 +1,44 @@
+//
+//  ElementLocationTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class ElementLocationTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/location"
+    
+    func testElementLocationCoodinates() {
+        let response = """
+        {
+          "value": {
+            "y": 68,
+            "x": 15
+          }
+        }
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        let elementPoint = try! element.getElementLocation()
+        XCTAssertTrue(elementPoint.xCoord == 15)
+        XCTAssertTrue(elementPoint.yCoord == 68)
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/ElementRectTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/ElementRectTests.swift
@@ -1,0 +1,48 @@
+//
+//  ElementRectTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class ElementRectTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/rect"
+    
+    func testElementRect() {
+        let response = """
+        {
+          "value": {
+            "y": 68,
+            "x": 15,
+            "width": 30,
+            "height": 100
+          }
+        }
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        let elementRect = try! element.getElementRect()
+        XCTAssertTrue(elementRect.width == 30)
+        XCTAssertTrue(elementRect.height == 100)
+        XCTAssertTrue(elementRect.yCoord == 68)
+        XCTAssertTrue(elementRect.xCoord == 15)
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/ElementSizeTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/ElementSizeTests.swift
@@ -1,0 +1,44 @@
+//
+//  ElementSizeTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class ElementSizeTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/size"
+    
+    func testElementSize() {
+        let response = """
+        {
+          "value": {
+            "width": 30,
+            "height": 100
+          }
+        }
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        let elementSize = try! element.getElementSize()
+        XCTAssertTrue(elementSize.width == 30)
+        XCTAssertTrue(elementSize.height == 100)
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/EnabledTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/EnabledTests.swift
@@ -1,0 +1,37 @@
+//
+//  EnabledTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class EnabledTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/enabled"
+    
+    func testElementEnabled() {
+        let response = """
+            {"value":true}
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertTrue(try! element.isEnabled())
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/GetElementTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/GetElementTests.swift
@@ -1,0 +1,37 @@
+//
+//  GetElementTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 13.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetElementTests: AppiumSwiftClientTestBase {
+    
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/attribute/enabled"
+
+    func testSendKeys() {
+        let response = """
+            {"value":"true"}
+        """.data(using: .utf8)!
+        
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+
+        stub(matcher, jsonData(response, status: 200))
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertEqual(try element.getElementAttribute(with: "enabled"), "true")
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/GetTagNameTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/GetTagNameTests.swift
@@ -1,0 +1,36 @@
+//
+//  GetTagNameTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 08.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetTagNameTests: AppiumSwiftClientTestBase {
+    
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/name"
+    
+    func testGetElementTagNameText() {
+        let response = """
+            {"value":"XCUIElementTypeStaticText"}
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertEqual(try? element.getTagName(), "XCUIElementTypeStaticText")
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/GetTextTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/GetTextTests.swift
@@ -1,0 +1,36 @@
+//
+//  GetTextTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 08.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class GetTextTests: AppiumSwiftClientTestBase {
+    
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/text"
+    
+    func testGetElementText() {
+        let response = """
+            {"value":"Dummy Text"}
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertEqual(try? element.getText(), "Dummy Text")
+    }
+}

--- a/AppiumSwiftClientUnitTests/command/W3C/element/SelectedTests.swift
+++ b/AppiumSwiftClientUnitTests/command/W3C/element/SelectedTests.swift
@@ -1,0 +1,37 @@
+//
+//  SelectedTests.swift
+//  AppiumSwiftClientUnitTests
+//
+//  Created by Gabriel Fioretti on 20.07.20.
+//  Copyright © 2020 KazuCocoa. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Mockingjay
+
+@testable import AppiumSwiftClient
+
+class SelectedTests: AppiumSwiftClientTestBase {
+
+    let url = "http://127.0.0.1:4723/wd/hub/session/3CB9E12B-419C-49B1-855A-45322861F1F7/element/test-element-id/selected"
+    
+    func testElementSelected() {
+        let response = """
+            {"value":true}
+        """.data(using: .utf8)!
+
+        func matcher(request: URLRequest) -> Bool {
+            if (request.url?.absoluteString == url) {
+                XCTAssertEqual(HttpMethod.get.rawValue, request.httpMethod)
+                return true
+            } else {
+                return false
+            }
+        }
+        stub(matcher, jsonData(response, status: 200))
+
+        let element = MobileElement(id: "test-element-id", sessionId: "3CB9E12B-419C-49B1-855A-45322861F1F7")
+        XCTAssertTrue(try! element.isSelected())
+    }
+}


### PR DESCRIPTION
Implements the following endpoints:
- [Get Element Text Endpoint](https://appium.io/docs/en/commands/element/attributes/text/)
- [Get Tag Name Endpoint](https://appium.io/docs/en/commands/element/attributes/name/)
- [Get Element Attribute Endpoint](https://appium.io/docs/en/commands/element/attributes/attribute/)
- [Is Element Selected Endpoint](https://appium.io/docs/en/commands/element/attributes/selected/)
- [Is Element Enabled Endpoint](https://appium.io/docs/en/commands/element/attributes/enabled/)
- [Is Element Displayed Endpoint](https://appium.io/docs/en/commands/element/attributes/displayed/)
- [Get Element Location Endpoint](https://appium.io/docs/en/commands/element/attributes/location/)
- [Get Element Size Endpoint](https://appium.io/docs/en/commands/element/attributes/size/)
- [Get Element Rect Endpoint](https://appium.io/docs/en/commands/element/attributes/rect/)

Get Element CSS Value Endpoint was deliberately not implemented as it requires some Selenium methods to be implemented that I consider out of scope at this moment and should be addressed when tackling Mobile Web test. Get Element Location in View Endpoint was also left out as it is mostly an internal endpoint and not even implemented in other highly adopted clients i.e. Java or Ruby.